### PR TITLE
Improve logging and remove duplicate render loops

### DIFF
--- a/src/main/java/com/thunder/NovaAPI/RenderEngine/instancing/InstancedRenderer.java
+++ b/src/main/java/com/thunder/NovaAPI/RenderEngine/instancing/InstancedRenderer.java
@@ -34,30 +34,6 @@ public class InstancedRenderer {
             GL31.glDrawElementsInstanced(GL30.GL_TRIANGLES, 36, GL30.GL_UNSIGNED_INT, 0, entityList.size());
         }
 
-        GL30.glBindVertexArray(0);
-
-
-
-
-
-        for (Entity entity : entities) {
-            if (!frustum.isVisible(entity.getBoundingBox())) continue;
-
-            ResourceLocation modelPath = ModelRegistryHelper.getModelPath(entity.getType());
-            batched.computeIfAbsent(modelPath, k -> new ArrayList<>()).add(entity);
-        }
-
-        for (Map.Entry<ResourceLocation, List<Entity>> entry : batched.entrySet()) {
-            ResourceLocation modelPath = entry.getKey();
-            List<Entity> entityList = entry.getValue();
-
-            int vao = VAOManager.getOrLoadVAO(modelPath);
-            if (!VAOManager.isModelEnabled(modelPath) || vao <= 0) continue;
-
-            GL30.glBindVertexArray(vao);
-            GL31.glDrawElementsInstanced(GL30.GL_TRIANGLES, 36, GL30.GL_UNSIGNED_INT, 0, entityList.size());
-        }
-
         GL30.glBindVertexArray(0); // clean unbind
     }
 }

--- a/src/main/java/com/thunder/NovaAPI/chunk/ChunkPreloader.java
+++ b/src/main/java/com/thunder/NovaAPI/chunk/ChunkPreloader.java
@@ -12,7 +12,7 @@ import java.util.concurrent.Executors;
 
 
 public class ChunkPreloader {
-    private static final int THREAD_POOL_SIZE = Runtime.getRuntime().availableProcessors() - 1;
+    private static final int THREAD_POOL_SIZE = Math.max(1, Runtime.getRuntime().availableProcessors() - 1);
     private static final ExecutorService CHUNK_LOADING_EXECUTOR = Executors.newFixedThreadPool(THREAD_POOL_SIZE);
     private static final ConcurrentLinkedQueue<ChunkLoadRequest> chunkQueue = new ConcurrentLinkedQueue<>();
 


### PR DESCRIPTION
## Summary
- tidy thread monitor logs using logger
- guard chunk preloader thread pool size
- remove duplicate loops in instanced renderer

## Testing
- `./gradlew test --info`

------
https://chatgpt.com/codex/tasks/task_e_68785e976a488328ac3bad020829645a