### PR TITLE
Add unload-aware cache and memory debug tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,7 @@ Additional Resources:
 ==========
 Community Documentation: https://docs.neoforged.net/  
 NeoForged Discord: https://discord.neoforged.net/
+
+Performance and Memory Guidelines:
+=====================
+See [Memory and Performance Guidelines](docs/memory-and-performance-guidelines.md) for NovaAPI-specific recommendations to avoid leaks and keep NeoForge mods efficient.

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ group = "com.thunder.NovaAPI"
 
 repositories {
     mavenLocal()
+    mavenCentral()
 }
 
 base {
@@ -114,6 +115,8 @@ configurations {
 
 dependencies {
 
+    // Primitive collections to minimize boxed overhead in hot caches.
+    implementation "it.unimi.dsi:fastutil:8.5.12"
 
     // Embed Kryo inside your mod while avoiding conflicts
     jarJar(implementation("com.esotericsoftware:kryo:5.6.2")) {

--- a/docs/memory-and-performance-guidelines.md
+++ b/docs/memory-and-performance-guidelines.md
@@ -1,0 +1,56 @@
+# Memory and Performance Guidelines for NeoForge Mods
+
+These practices keep NovaAPI-using mods lean and avoid hidden memory pressure when building with NeoForge and Gradle.
+
+## 1. Prevent accidental world retention (hidden RAM killer)
+- Do **not** keep long-lived references to heavy Minecraft objects (`Level`, `ServerLevel`, `ChunkAccess`/`LevelChunk`, `BlockEntity`, `Entity`, `Player`, `Biome`, `BlockState`) in static singletons or caches.
+- Store identifiers instead:
+  - Dimension: `ResourceKey<Level>`
+  - Position: `BlockPos.asLong()`
+  - Entity: `UUID` (or short-lived entity ID)
+- For fast lookups, use maps keyed by dimension + `longPos` instead of holding chunk references.
+- Rule of thumb: holding a chunk reference can keep an entire region loaded in memory.
+
+## 2. Eliminate per-tick allocations
+- Avoid constant allocations that grow the heap and drive GC pressure.
+- Common culprits: new `ArrayList`/`HashMap` each tick, many `BlockPos`/`Vec3` creations, lambdas/streams, string concatenation in hot paths.
+- Fixes: reuse buffers (`IntArrayList`, `LongArrayList`, pre-sized arrays), prefer for-loops over streams in hot paths, use `MutableBlockPos` for iteration, and build debug strings only when debugging is enabled.
+
+## 3. Prefer primitive collections
+- Replace boxed collections with primitive variants to cut memory use (often 2–5× savings).
+- Examples: `Map<Long, Foo>` instead of `Map<BlockPos, Foo>` (store `BlockPos.asLong()`), `Long2ObjectOpenHashMap`, `LongOpenHashSet`, and other fastutil primitives.
+
+## 4. Cap caches and make them expire
+- Any cache tied to exploration can grow without bound.
+- Best practices:
+  - Use LRU or size-limited caches (max entries or max bytes).
+  - Add TTL for “nice to have” cached data.
+  - Make caches dimension-scoped and unload-aware (purge entries on chunk unload).
+- If NovaAPI does chunk preloading or structure tracking, cap the cache.
+
+## 5. Avoid caching derived data that is cheap to recompute
+- Examples of risky cached data: full lists of nearby blocks/entities every tick, prebuilt path nodes, full NBT blobs stored for convenience.
+- Better options: store a small summary (hash/version/timestamp), recompute on demand, or store compressed/serialized forms when recomputation is truly expensive.
+
+## 6. Store large datasets serialized and compact
+- For big datasets (migration maps, structure indexes, scan results):
+  - Store compact primitives (`int`/`long`).
+  - Store compressed bytes (LZ4/gzip) and inflate only when needed.
+  - Keep data on disk and memory-map/page it in; load per region when possible.
+- Prefer region-based indexing: key by `ChunkPos`/region coordinates and keep only active regions hot in RAM.
+
+## 7. Avoid listener leaks and static registries that never clear
+- Leaks often come from callbacks that are never unregistered:
+  - Event-bus listeners kept in static instances.
+  - Scheduled tasks retaining closures with world/player references.
+  - Thread pools holding runnables with captured data.
+- Fixes: on server stop or datapack reload, clear caches, cancel tasks, and shut down executors. Avoid background tasks that capture `Level`/`Player` references.
+
+## 8. Track memory like TPS during development
+- Add a dev-only “memory + top caches” debug command/log that reports:
+  - Total heap used.
+  - Sizes of major caches.
+  - Entry counts per dimension.
+  - Estimated bytes per entry (rough estimates are useful).
+
+Incorporate these patterns into NovaAPI features and integrations to keep servers stable and memory-efficient.

--- a/src/main/java/com/thunder/novaapi/NovaAPI.java
+++ b/src/main/java/com/thunder/novaapi/NovaAPI.java
@@ -1,0 +1,48 @@
+package com.thunder.novaapi;
+
+import com.thunder.novaapi.cache.RegionScopedCache;
+import com.thunder.novaapi.command.MemoryDebugCommand;
+import com.thunder.novaapi.task.BackgroundTaskScheduler;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.LevelAccessor;
+import net.neoforged.fml.common.Mod;
+import net.neoforged.neoforge.common.NeoForge;
+import net.neoforged.neoforge.event.RegisterCommandsEvent;
+import net.neoforged.neoforge.event.level.ChunkEvent;
+import net.neoforged.neoforge.event.server.ServerStoppingEvent;
+
+@Mod(NovaAPI.MOD_ID)
+public class NovaAPI {
+    public static final String MOD_ID = "novaapi";
+
+    /**
+     * Shared cache for dimension + chunk scoped data. This cache is capped, TTL-governed, and unload-aware.
+     */
+    public static final RegionScopedCache<String> REGION_CACHE = new RegionScopedCache<>(512, 10 * 60 * 1000L);
+
+    public NovaAPI(@SuppressWarnings("unused") net.neoforged.bus.api.IEventBus modBus) {
+        NeoForge.EVENT_BUS.addListener(this::onRegisterCommands);
+        NeoForge.EVENT_BUS.addListener(this::onChunkUnload);
+        NeoForge.EVENT_BUS.addListener(this::onServerStopping);
+    }
+
+    private void onRegisterCommands(RegisterCommandsEvent event) {
+        MemoryDebugCommand.register(event.getDispatcher());
+    }
+
+    private void onChunkUnload(ChunkEvent.Unload event) {
+        LevelAccessor level = event.getLevel();
+        if (level instanceof Level fullLevel) {
+            ResourceKey<Level> dimension = fullLevel.dimension();
+            ChunkPos chunkPos = event.getChunk().getPos();
+            REGION_CACHE.remove(dimension, chunkPos);
+        }
+    }
+
+    private void onServerStopping(ServerStoppingEvent event) {
+        REGION_CACHE.clear();
+        BackgroundTaskScheduler.shutdown();
+    }
+}

--- a/src/main/java/com/thunder/novaapi/cache/RegionScopedCache.java
+++ b/src/main/java/com/thunder/novaapi/cache/RegionScopedCache.java
@@ -1,0 +1,109 @@
+package com.thunder.novaapi.cache;
+
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * An unload-aware, TTL-governed cache that keys entries by dimension + chunk position (as a long).
+ *
+ * @param <V> value type stored in the cache
+ */
+public class RegionScopedCache<V> {
+    private final Map<ResourceKey<Level>, Long2ObjectOpenHashMap<Entry<V>>> caches = new HashMap<>();
+    private final int maxEntriesPerDimension;
+    private final long ttlMillis;
+
+    public RegionScopedCache(int maxEntriesPerDimension, long ttlMillis) {
+        this.maxEntriesPerDimension = maxEntriesPerDimension;
+        this.ttlMillis = ttlMillis;
+    }
+
+    public synchronized V getOrCompute(ResourceKey<Level> dimension, ChunkPos chunkPos, Supplier<V> supplier) {
+        Objects.requireNonNull(dimension, "dimension");
+        Objects.requireNonNull(chunkPos, "chunkPos");
+        Objects.requireNonNull(supplier, "supplier");
+
+        Long2ObjectOpenHashMap<Entry<V>> cache = caches.computeIfAbsent(dimension, ignored -> new Long2ObjectOpenHashMap<>());
+        long key = chunkPos.toLong();
+
+        purgeExpired(cache);
+        Entry<V> existing = cache.get(key);
+        if (existing != null) {
+            return existing.value();
+        }
+
+        V value = supplier.get();
+        cache.put(key, new Entry<>(value, Instant.now().toEpochMilli()));
+        enforceLimit(cache);
+        return value;
+    }
+
+    public synchronized void remove(ResourceKey<Level> dimension, ChunkPos chunkPos) {
+        Long2ObjectOpenHashMap<Entry<V>> cache = caches.get(dimension);
+        if (cache != null) {
+            cache.remove(chunkPos.toLong());
+            if (cache.isEmpty()) {
+                caches.remove(dimension);
+            }
+        }
+    }
+
+    public synchronized void clear() {
+        caches.clear();
+    }
+
+    public synchronized Metrics metrics() {
+        int dimensions = caches.size();
+        long entries = caches.values().stream().mapToLong(Long2ObjectOpenHashMap::size).sum();
+        return new Metrics(dimensions, entries, ttlMillis, maxEntriesPerDimension);
+    }
+
+    private void enforceLimit(Long2ObjectOpenHashMap<Entry<V>> cache) {
+        while (cache.size() > maxEntriesPerDimension) {
+            // Remove the oldest entry to stay under the cap.
+            long[] keys = cache.keySet().toLongArray();
+            Entry<V>[] values = cache.values().toArray(new Entry[0]);
+            long oldestTimestamp = Long.MAX_VALUE;
+            long oldestKey = 0;
+
+            for (int i = 0; i < keys.length; i++) {
+                Entry<V> entry = values[i];
+                if (entry != null && entry.createdAt() < oldestTimestamp) {
+                    oldestTimestamp = entry.createdAt();
+                    oldestKey = keys[i];
+                }
+            }
+
+            cache.remove(oldestKey);
+        }
+    }
+
+    private void purgeExpired(Long2ObjectOpenHashMap<Entry<V>> cache) {
+        if (cache.isEmpty() || ttlMillis <= 0) {
+            return;
+        }
+
+        long cutoff = Instant.now().toEpochMilli() - ttlMillis;
+        long[] keys = cache.keySet().toLongArray();
+        for (long key : keys) {
+            Entry<V> entry = cache.get(key);
+            if (entry != null && entry.createdAt() < cutoff) {
+                cache.remove(key);
+            }
+        }
+    }
+
+    public record Metrics(int trackedDimensions, long cachedEntries, long ttlMillis, int maxEntriesPerDimension) {
+    }
+
+    private record Entry<V>(V value, long createdAt) {
+    }
+}

--- a/src/main/java/com/thunder/novaapi/command/MemoryDebugCommand.java
+++ b/src/main/java/com/thunder/novaapi/command/MemoryDebugCommand.java
@@ -1,0 +1,61 @@
+package com.thunder.novaapi.command;
+
+import com.thunder.novaapi.NovaAPI;
+import com.thunder.novaapi.cache.RegionScopedCache;
+import com.thunder.novaapi.task.BackgroundTaskScheduler;
+import com.mojang.brigadier.CommandDispatcher;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+
+/**
+ * Dev-only command to report heap usage and cache pressure. Helps track memory like TPS.
+ */
+public final class MemoryDebugCommand {
+    private MemoryDebugCommand() {
+    }
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
+        dispatcher.register(Commands.literal("novaapi")
+                .then(Commands.literal("memory")
+                        .requires(source -> source.hasPermission(2))
+                        .executes(ctx -> {
+                            sendMemoryReport(ctx.getSource(), NovaAPI.REGION_CACHE);
+                            return 1;
+                        }))
+                .then(Commands.literal("tasks")
+                        .requires(source -> source.hasPermission(2))
+                        .executes(ctx -> {
+                            BackgroundTaskScheduler.submit(ctx.getSource().getLevel().dimension(), 0L, () -> {
+                                // no-op sanity check; keeps dimension usage lightweight
+                            });
+                            ctx.getSource().sendSystemMessage(Component.literal("Background task executor is active (no Level retention)."));
+                            return 1;
+                        })));
+    }
+
+    private static void sendMemoryReport(CommandSourceStack source, RegionScopedCache<?> cache) {
+        Runtime runtime = Runtime.getRuntime();
+        long used = runtime.totalMemory() - runtime.freeMemory();
+        long max = runtime.maxMemory();
+        RegionScopedCache.Metrics metrics = cache.metrics();
+
+        source.sendSystemMessage(Component.literal("NovaAPI Memory Report"));
+        source.sendSystemMessage(Component.literal("- Heap used: " + humanReadableBytes(used)));
+        source.sendSystemMessage(Component.literal("- Heap max:  " + humanReadableBytes(max)));
+        source.sendSystemMessage(Component.literal("- Cache dimensions: " + metrics.trackedDimensions()));
+        source.sendSystemMessage(Component.literal("- Cache entries: " + metrics.cachedEntries()));
+        source.sendSystemMessage(Component.literal("- Cache TTL (ms): " + metrics.ttlMillis()));
+        source.sendSystemMessage(Component.literal("- Cache cap per dimension: " + metrics.maxEntriesPerDimension()));
+    }
+
+    private static String humanReadableBytes(long bytes) {
+        if (bytes < 1024) {
+            return bytes + " B";
+        }
+        int unit = 1024;
+        int exp = (int) (Math.log(bytes) / Math.log(unit));
+        char pre = "KMGTPE".charAt(exp - 1);
+        return String.format("%.1f %sB", bytes / Math.pow(unit, exp), pre);
+    }
+}

--- a/src/main/java/com/thunder/novaapi/task/BackgroundTaskScheduler.java
+++ b/src/main/java/com/thunder/novaapi/task/BackgroundTaskScheduler.java
@@ -1,0 +1,36 @@
+package com.thunder.novaapi.task;
+
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.Level;
+
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.function.Supplier;
+
+/**
+ * Manages background tasks while keeping dimension references lightweight (ResourceKey only).
+ */
+public final class BackgroundTaskScheduler {
+    private static final ExecutorService EXECUTOR = Executors.newFixedThreadPool(2);
+
+    private BackgroundTaskScheduler() {
+    }
+
+    public static Future<?> submit(ResourceKey<Level> dimension, long chunkPos, Runnable task) {
+        Objects.requireNonNull(dimension, "dimension");
+        Objects.requireNonNull(task, "task");
+        return EXECUTOR.submit(() -> task.run());
+    }
+
+    public static <T> Future<T> submit(ResourceKey<Level> dimension, long chunkPos, Supplier<T> supplier) {
+        Objects.requireNonNull(dimension, "dimension");
+        Objects.requireNonNull(supplier, "supplier");
+        return EXECUTOR.submit(supplier::get);
+    }
+
+    public static void shutdown() {
+        EXECUTOR.shutdownNow();
+    }
+}


### PR DESCRIPTION
## Summary
- add an unload-aware, TTL-capped region cache keyed by dimension and chunk for NovaAPI usage
- register a /novaapi memory command plus cleanup hooks to report heap/cache metrics and clear caches on unload/server stop
- add a lightweight background task scheduler and fastutil dependency to avoid boxed collections
- improve cache eviction robustness and clarify background task sanity check message

## Testing
- ./gradlew build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69598b6650908328a73ffb8bebccd052)