### PR TITLE
Ensure integration tests run via JUnit Platform

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -260,6 +260,10 @@ tasks.register('integrationTest', Test) {
     shouldRunAfter tasks.named('test')
 }
 
+tasks.withType(Test).configureEach {
+    useJUnitPlatform()
+}
+
 tasks.register('profileChunkWorkload', JavaExec) {
     group = 'performance'
     description = 'Executes the chunk workload driver with JFR and optional async-profiler attached.'


### PR DESCRIPTION
## Summary
- configure all Gradle test tasks to use the JUnit Platform so integration and unit tests are discovered

## Testing
- ./gradlew integrationTest --console=plain

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6959e88a1f348328b24f836216ae9805)