### PR TITLE
Route all config registrations through validator

### DIFF
--- a/src/main/java/com/thunder/novaapi/Core/NovaAPI.java
+++ b/src/main/java/com/thunder/novaapi/Core/NovaAPI.java
@@ -87,11 +87,10 @@ public class NovaAPI {
         modEventBus.addListener(this::onConfigLoaded);
         modEventBus.addListener(this::onConfigReloaded);
 
-        container.registerConfig(ModConfig.Type.COMMON, NovaAPIConfig.CONFIG);
-        container.registerConfig(ModConfig.Type.COMMON, AsyncThreadingConfig.CONFIG_SPEC, "novaapi-async.toml");
-        container.registerConfig(ModConfig.Type.COMMON, ChunkStreamingConfig.CONFIG_SPEC, "novaapi-chunk-streaming.toml");
-
         NeoForge.EVENT_BUS.register(this);
+
+        ConfigRegistrationValidator.register(container, ModConfig.Type.COMMON, NovaAPIConfig.CONFIG,
+                CONFIG_FOLDER + "wildernessodysseyapi-common.toml");
 
         ConfigRegistrationValidator.register(container, ModConfig.Type.COMMON, ModDataCacheConfig.CONFIG_SPEC,
                 CONFIG_FOLDER + "wildernessodysseyapi-cache.toml");


### PR DESCRIPTION
## Summary
- register the NovaAPI config via ConfigRegistrationValidator so all configs go through the same validation path
- rely solely on validator-based registrations to avoid duplicate config registrations with inconsistent filenames

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695adc9f92f883289b9e260d7e277a7c)