### PR TITLE
Add configuration option for NovaAPI debug logging

### DIFF
--- a/src/main/java/com/thunder/novaapi/Core/NovaAPI.java
+++ b/src/main/java/com/thunder/novaapi/Core/NovaAPI.java
@@ -54,6 +54,8 @@ import net.neoforged.neoforge.event.server.ServerStoppingEvent;
 import net.neoforged.neoforge.event.tick.ServerTickEvent;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 
 import java.nio.file.Path;
 import java.util.Optional;
@@ -79,6 +81,7 @@ public class NovaAPI {
     private static long worstTickTimeNanos = 0L;
     private static int serverTickCounter = 0;
     private final requestperfadvice requestperfadvice = new requestperfadvice();
+    private static boolean debugLoggingEnabled = false;
 
     public NovaAPI(IEventBus modEventBus, ModContainer container) {
         LOGGER.info("NovaAPI initialized with async + chunk streaming pipeline.");
@@ -101,6 +104,8 @@ public class NovaAPI {
 
         ConfigRegistrationValidator.register(container, ModConfig.Type.COMMON, ChunkStreamingConfig.CONFIG_SPEC,
                 CONFIG_FOLDER + "novaapi-chunk-streaming.toml");
+
+        applyDebugLoggingConfig();
     }
 
     private void commonSetup(final FMLCommonSetupEvent event) {
@@ -245,6 +250,9 @@ public class NovaAPI {
     }
 
     public void onConfigLoaded(ModConfigEvent.Loading event) {
+        if (event.getConfig().getSpec() == NovaAPIConfig.CONFIG) {
+            applyDebugLoggingConfig();
+        }
         if (event.getConfig().getSpec() == ModDataCacheConfig.CONFIG_SPEC) {
             ModDataCache.initialize();
         }
@@ -257,6 +265,9 @@ public class NovaAPI {
     }
 
     public void onConfigReloaded(ModConfigEvent.Reloading event) {
+        if (event.getConfig().getSpec() == NovaAPIConfig.CONFIG) {
+            applyDebugLoggingConfig();
+        }
         if (event.getConfig().getSpec() == ModDataCacheConfig.CONFIG_SPEC) {
             ModDataCache.initialize();
         }
@@ -280,5 +291,16 @@ public class NovaAPI {
 
     public static void shutdown() {
         ThreadMonitor.stopMonitoring();
+    }
+
+    private void applyDebugLoggingConfig() {
+        boolean enableDebug = NovaAPIConfig.ENABLE_DEBUG_LOGGING.get();
+        if (enableDebug == debugLoggingEnabled) {
+            return;
+        }
+        debugLoggingEnabled = enableDebug;
+        Level targetLevel = enableDebug ? Level.DEBUG : Level.INFO;
+        Configurator.setLevel(LOGGER.getName(), targetLevel);
+        LOGGER.info("[NovaAPI] {} debug logging.", enableDebug ? "Enabled" : "Disabled");
     }
 }

--- a/src/main/java/com/thunder/novaapi/config/NovaAPIConfig.java
+++ b/src/main/java/com/thunder/novaapi/config/NovaAPIConfig.java
@@ -8,6 +8,7 @@ public class NovaAPIConfig {
 
     // 🔹 General Settings
     public static final ModConfigSpec.BooleanValue ENABLE_NOVA_API;
+    public static final ModConfigSpec.BooleanValue ENABLE_DEBUG_LOGGING;
 
     // 🔹 Chunk Optimization Settings
     public static final ModConfigSpec.BooleanValue ENABLE_CHUNK_OPTIMIZATIONS;
@@ -19,6 +20,9 @@ public class NovaAPIConfig {
         ENABLE_NOVA_API = BUILDER
                 .comment("Enable Nova API. If false, all features are disabled.")
                 .define("enableNovaAPI", true);
+        ENABLE_DEBUG_LOGGING = BUILDER
+                .comment("Enable NovaAPI debug-level logging without changing Minecraft's global log level.")
+                .define("enableDebugLogging", false);
         BUILDER.pop();
 
         BUILDER.push("Chunk Optimization Settings");


### PR DESCRIPTION
## Summary
- add an `enableDebugLogging` toggle to NovaAPI's general config section
- adjust the NovaAPI logger level when configs load or reload to honor the new toggle

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b012016b08328bb38bcc36e40b56e)