### PR TITLE
Add configuration option for NovaAPI debug logging

### DIFF
--- a/src/main/java/com/thunder/novaapi/Core/NovaAPI.java
+++ b/src/main/java/com/thunder/novaapi/Core/NovaAPI.java
@@ -22,6 +22,7 @@ import com.thunder.novaapi.chunk.ChunkTickThrottler;
 import com.thunder.novaapi.command.*;
 import com.thunder.novaapi.config.ConfigRegistrationValidator;
 import com.thunder.novaapi.config.NovaAPIConfig;
+import com.thunder.novaapi.config.DebugLoggingConfigurator;
 import com.thunder.novaapi.io.BufferPool;
 import com.thunder.novaapi.io.IoExecutors;
 import com.thunder.novaapi.task.BackgroundTaskScheduler;
@@ -101,6 +102,8 @@ public class NovaAPI {
 
         ConfigRegistrationValidator.register(container, ModConfig.Type.COMMON, ChunkStreamingConfig.CONFIG_SPEC,
                 CONFIG_FOLDER + "novaapi-chunk-streaming.toml");
+
+        DebugLoggingConfigurator.apply(LOGGER);
     }
 
     private void commonSetup(final FMLCommonSetupEvent event) {
@@ -245,6 +248,9 @@ public class NovaAPI {
     }
 
     public void onConfigLoaded(ModConfigEvent.Loading event) {
+        if (event.getConfig().getSpec() == NovaAPIConfig.CONFIG) {
+            DebugLoggingConfigurator.apply(LOGGER);
+        }
         if (event.getConfig().getSpec() == ModDataCacheConfig.CONFIG_SPEC) {
             ModDataCache.initialize();
         }
@@ -257,6 +263,9 @@ public class NovaAPI {
     }
 
     public void onConfigReloaded(ModConfigEvent.Reloading event) {
+        if (event.getConfig().getSpec() == NovaAPIConfig.CONFIG) {
+            DebugLoggingConfigurator.apply(LOGGER);
+        }
         if (event.getConfig().getSpec() == ModDataCacheConfig.CONFIG_SPEC) {
             ModDataCache.initialize();
         }

--- a/src/main/java/com/thunder/novaapi/config/DebugLoggingConfigurator.java
+++ b/src/main/java/com/thunder/novaapi/config/DebugLoggingConfigurator.java
@@ -1,0 +1,27 @@
+package com.thunder.novaapi.config;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
+
+/**
+ * Applies NovaAPI-specific debug logging settings without changing Minecraft's global log level.
+ */
+public final class DebugLoggingConfigurator {
+
+    private static boolean debugLoggingEnabled = false;
+
+    private DebugLoggingConfigurator() {
+    }
+
+    public static void apply(Logger logger) {
+        boolean enableDebug = NovaAPIConfig.ENABLE_DEBUG_LOGGING.get();
+        if (enableDebug == debugLoggingEnabled) {
+            return;
+        }
+        debugLoggingEnabled = enableDebug;
+        Level targetLevel = enableDebug ? Level.DEBUG : Level.INFO;
+        Configurator.setLevel(logger.getName(), targetLevel);
+        logger.info("[NovaAPI] {} debug logging.", enableDebug ? "Enabled" : "Disabled");
+    }
+}

--- a/src/main/java/com/thunder/novaapi/config/NovaAPIConfig.java
+++ b/src/main/java/com/thunder/novaapi/config/NovaAPIConfig.java
@@ -8,6 +8,7 @@ public class NovaAPIConfig {
 
     // 🔹 General Settings
     public static final ModConfigSpec.BooleanValue ENABLE_NOVA_API;
+    public static final ModConfigSpec.BooleanValue ENABLE_DEBUG_LOGGING;
 
     // 🔹 Chunk Optimization Settings
     public static final ModConfigSpec.BooleanValue ENABLE_CHUNK_OPTIMIZATIONS;
@@ -19,6 +20,9 @@ public class NovaAPIConfig {
         ENABLE_NOVA_API = BUILDER
                 .comment("Enable Nova API. If false, all features are disabled.")
                 .define("enableNovaAPI", true);
+        ENABLE_DEBUG_LOGGING = BUILDER
+                .comment("Enable NovaAPI debug-level logging without changing Minecraft's global log level.")
+                .define("enableDebugLogging", false);
         BUILDER.pop();
 
         BUILDER.push("Chunk Optimization Settings");


### PR DESCRIPTION
## Summary
- add an `enableDebugLogging` toggle to NovaAPI's general config section
- move debug logging level switching into a dedicated configurator class used during load and reload events

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b012016b08328bb38bcc36e40b56e)