### PR TITLE
Add overlay batching and particle culling with per-feature config

### DIFF
--- a/src/main/java/com/thunder/novaapi/Core/NovaAPI.java
+++ b/src/main/java/com/thunder/novaapi/Core/NovaAPI.java
@@ -21,6 +21,7 @@ import com.thunder.novaapi.chunk.ChunkTickThrottler;
 import com.thunder.novaapi.command.*;
 import com.thunder.novaapi.config.ConfigRegistrationValidator;
 import com.thunder.novaapi.config.NovaAPIConfig;
+import com.thunder.novaapi.RenderEngine.RenderEngineConfig;
 import com.thunder.novaapi.io.BufferPool;
 import com.thunder.novaapi.io.IoExecutors;
 import com.thunder.novaapi.task.BackgroundTaskScheduler;
@@ -100,6 +101,9 @@ public class NovaAPI {
 
         ConfigRegistrationValidator.register(container, ModConfig.Type.COMMON, ChunkStreamingConfig.CONFIG_SPEC,
                 CONFIG_FOLDER + "novaapi-chunk-streaming.toml");
+
+        ConfigRegistrationValidator.register(container, ModConfig.Type.COMMON, RenderEngineConfig.CONFIG_SPEC,
+                CONFIG_FOLDER + "novaapi-rendering.toml");
     }
 
     private void commonSetup(final FMLCommonSetupEvent event) {

--- a/src/main/java/com/thunder/novaapi/RenderEngine/API/ParticleCullingAPI.java
+++ b/src/main/java/com/thunder/novaapi/RenderEngine/API/ParticleCullingAPI.java
@@ -1,0 +1,16 @@
+package com.thunder.novaapi.RenderEngine.API;
+
+import com.thunder.novaapi.RenderEngine.particles.ParticleCullingManager;
+import net.minecraft.world.phys.Vec3;
+
+public final class ParticleCullingAPI {
+    private ParticleCullingAPI() {
+    }
+
+    /**
+     * Queue a particle render submission that will be culled by distance and frustum before rendering.
+     */
+    public static void queueParticle(Vec3 position, float radius, Runnable submit) {
+        ParticleCullingManager.queue(new ParticleCullingManager.ParticleRenderRequest(position, radius, submit));
+    }
+}

--- a/src/main/java/com/thunder/novaapi/RenderEngine/API/RenderOverlayAPI.java
+++ b/src/main/java/com/thunder/novaapi/RenderEngine/API/RenderOverlayAPI.java
@@ -1,0 +1,26 @@
+package com.thunder.novaapi.RenderEngine.API;
+
+import com.thunder.novaapi.RenderEngine.overlay.OverlayBatcher;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.function.Consumer;
+
+public final class RenderOverlayAPI {
+    private RenderOverlayAPI() {
+    }
+
+    /**
+     * Queue an overlay draw call that will be grouped by texture where possible.
+     */
+    public static void queueOverlay(ResourceLocation texture, Consumer<GuiGraphics> drawCall) {
+        OverlayBatcher.queue(texture, drawCall);
+    }
+
+    /**
+     * Queue an overlay draw call without specifying a texture.
+     */
+    public static void queueOverlay(Consumer<GuiGraphics> drawCall) {
+        OverlayBatcher.queue(drawCall);
+    }
+}

--- a/src/main/java/com/thunder/novaapi/RenderEngine/ClientModEvents.java
+++ b/src/main/java/com/thunder/novaapi/RenderEngine/ClientModEvents.java
@@ -4,6 +4,8 @@ package com.thunder.novaapi.RenderEngine;
 import com.thunder.novaapi.Core.NovaAPI;
 import com.thunder.novaapi.RenderEngine.Threading.ModdedRenderInterceptor;
 import com.thunder.novaapi.RenderEngine.instancing.InstancedRenderer;
+import com.thunder.novaapi.RenderEngine.overlay.OverlayBatcher;
+import com.thunder.novaapi.RenderEngine.particles.ParticleCullingManager;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.neoforged.bus.api.SubscribeEvent;
@@ -21,6 +23,10 @@ public class ClientModEvents {
     public static void onRenderWorld(RenderLevelStageEvent event) {
         if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_PARTICLES) return;
 
+        ParticleCullingManager.render(
+                event.getFrustum(),
+                Minecraft.getInstance().gameRenderer.getMainCamera().getPosition()
+        );
         InstancedRenderer.renderAll(
                 Minecraft.getInstance().level.entitiesForRendering(),
                 event.getFrustum()
@@ -33,7 +39,7 @@ public class ClientModEvents {
         graphics.pose().pushPose();
         try {
             ModdedRenderInterceptor.executeModRender(() -> {
-                // Run actual GUI drawing here using graphics
+                OverlayBatcher.render(graphics);
             });
         } catch (Exception e) {
             NovaAPI.LOGGER.error("RenderInterceptor threw during overlay rendering", e);

--- a/src/main/java/com/thunder/novaapi/RenderEngine/RenderEngineConfig.java
+++ b/src/main/java/com/thunder/novaapi/RenderEngine/RenderEngineConfig.java
@@ -1,0 +1,46 @@
+package com.thunder.novaapi.RenderEngine;
+
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+public final class RenderEngineConfig {
+    public static final ModConfigSpec CONFIG_SPEC;
+    public static final ModConfigSpec.BooleanValue ENABLE_OVERLAY_BATCHING;
+    public static final ModConfigSpec.BooleanValue ENABLE_PARTICLE_CULLING;
+    public static final ModConfigSpec.IntValue PARTICLE_CULL_DISTANCE;
+
+    static {
+        ModConfigSpec.Builder builder = new ModConfigSpec.Builder();
+
+        builder.push("Overlay Rendering");
+        ENABLE_OVERLAY_BATCHING = builder
+                .comment("Group overlay draw calls by texture to reduce state changes.")
+                .define("enableOverlayBatching", true);
+        builder.pop();
+
+        builder.push("Particle Rendering");
+        ENABLE_PARTICLE_CULLING = builder
+                .comment("Cull modded particle submissions based on camera distance and frustum visibility.")
+                .define("enableParticleCulling", true);
+        PARTICLE_CULL_DISTANCE = builder
+                .comment("Maximum distance in blocks for modded particle submissions before culling.")
+                .defineInRange("particleCullingDistance", 128, 0, 4096);
+        builder.pop();
+
+        CONFIG_SPEC = builder.build();
+    }
+
+    private RenderEngineConfig() {
+    }
+
+    public static boolean isOverlayBatchingEnabled() {
+        return ENABLE_OVERLAY_BATCHING.get();
+    }
+
+    public static boolean isParticleCullingEnabled() {
+        return ENABLE_PARTICLE_CULLING.get();
+    }
+
+    public static int getParticleCullingDistance() {
+        return PARTICLE_CULL_DISTANCE.get();
+    }
+}

--- a/src/main/java/com/thunder/novaapi/RenderEngine/overlay/OverlayBatcher.java
+++ b/src/main/java/com/thunder/novaapi/RenderEngine/overlay/OverlayBatcher.java
@@ -1,0 +1,74 @@
+package com.thunder.novaapi.RenderEngine.overlay;
+
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.thunder.novaapi.RenderEngine.RenderEngineConfig;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.resources.ResourceLocation;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+public final class OverlayBatcher {
+    private static final List<OverlayCall> QUEUED_CALLS = new ArrayList<>();
+
+    private OverlayBatcher() {
+    }
+
+    public static void queue(ResourceLocation texture, Consumer<GuiGraphics> drawCall) {
+        Objects.requireNonNull(drawCall, "drawCall");
+        synchronized (QUEUED_CALLS) {
+            QUEUED_CALLS.add(new OverlayCall(texture, drawCall));
+        }
+    }
+
+    public static void queue(Consumer<GuiGraphics> drawCall) {
+        queue(null, drawCall);
+    }
+
+    public static void render(GuiGraphics graphics) {
+        List<OverlayCall> calls;
+        synchronized (QUEUED_CALLS) {
+            if (QUEUED_CALLS.isEmpty()) {
+                return;
+            }
+            calls = new ArrayList<>(QUEUED_CALLS);
+            QUEUED_CALLS.clear();
+        }
+
+        if (!RenderEngineConfig.isOverlayBatchingEnabled()) {
+            renderSequential(calls, graphics);
+            return;
+        }
+
+        Map<ResourceLocation, List<OverlayCall>> grouped = new LinkedHashMap<>();
+        for (OverlayCall call : calls) {
+            grouped.computeIfAbsent(call.texture(), key -> new ArrayList<>()).add(call);
+        }
+
+        for (Map.Entry<ResourceLocation, List<OverlayCall>> entry : grouped.entrySet()) {
+            ResourceLocation texture = entry.getKey();
+            if (texture != null) {
+                RenderSystem.setShaderTexture(0, texture);
+            }
+            for (OverlayCall call : entry.getValue()) {
+                call.drawCall().accept(graphics);
+            }
+        }
+    }
+
+    private static void renderSequential(List<OverlayCall> calls, GuiGraphics graphics) {
+        for (OverlayCall call : calls) {
+            if (call.texture() != null) {
+                RenderSystem.setShaderTexture(0, call.texture());
+            }
+            call.drawCall().accept(graphics);
+        }
+    }
+
+    private record OverlayCall(ResourceLocation texture, Consumer<GuiGraphics> drawCall) {
+    }
+}

--- a/src/main/java/com/thunder/novaapi/RenderEngine/particles/ParticleCullingManager.java
+++ b/src/main/java/com/thunder/novaapi/RenderEngine/particles/ParticleCullingManager.java
@@ -1,0 +1,68 @@
+package com.thunder.novaapi.RenderEngine.particles;
+
+import com.thunder.novaapi.RenderEngine.RenderEngineConfig;
+import net.minecraft.client.renderer.culling.Frustum;
+import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public final class ParticleCullingManager {
+    private static final List<ParticleRenderRequest> QUEUED_REQUESTS = new ArrayList<>();
+
+    private ParticleCullingManager() {
+    }
+
+    public static void queue(ParticleRenderRequest request) {
+        Objects.requireNonNull(request, "request");
+        synchronized (QUEUED_REQUESTS) {
+            QUEUED_REQUESTS.add(request);
+        }
+    }
+
+    public static void render(Frustum frustum, Vec3 cameraPosition) {
+        List<ParticleRenderRequest> requests;
+        synchronized (QUEUED_REQUESTS) {
+            if (QUEUED_REQUESTS.isEmpty()) {
+                return;
+            }
+            requests = new ArrayList<>(QUEUED_REQUESTS);
+            QUEUED_REQUESTS.clear();
+        }
+
+        if (!RenderEngineConfig.isParticleCullingEnabled()) {
+            for (ParticleRenderRequest request : requests) {
+                request.submit().run();
+            }
+            return;
+        }
+
+        int maxDistance = RenderEngineConfig.getParticleCullingDistance();
+        double maxDistanceSquared = maxDistance > 0 ? maxDistance * (double) maxDistance : Double.POSITIVE_INFINITY;
+
+        for (ParticleRenderRequest request : requests) {
+            if (cameraPosition != null && cameraPosition.distanceToSqr(request.position()) > maxDistanceSquared) {
+                continue;
+            }
+            if (frustum != null && !frustum.isVisible(request.bounds())) {
+                continue;
+            }
+            request.submit().run();
+        }
+    }
+
+    public record ParticleRenderRequest(Vec3 position, float radius, Runnable submit) {
+        public ParticleRenderRequest {
+            Objects.requireNonNull(position, "position");
+            Objects.requireNonNull(submit, "submit");
+        }
+
+        public AABB bounds() {
+            double r = Math.max(0.0D, radius);
+            return new AABB(position.x - r, position.y - r, position.z - r,
+                    position.x + r, position.y + r, position.z + r);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Reduce overlay rendering state changes by grouping multiple draw calls per texture to improve performance.
- Reduce particle submission workload by culling modded particle render requests based on camera distance and frustum visibility.
- Provide per-feature toggles so modpacks can disable overlay batching or particle culling when conflicts arise.
- Expose simple APIs so other mods can queue overlay draws and particle submissions into the new systems.

### Description
- Added `RenderEngineConfig` with `enableOverlayBatching`, `enableParticleCulling`, and `particleCullingDistance` config entries and registered the spec in `NovaAPI` (`novaapi-rendering.toml`).
- Implemented `OverlayBatcher` to queue overlay draw calls and group them by `ResourceLocation` texture, and added `RenderOverlayAPI.queueOverlay(...)` to submit calls.
- Implemented `ParticleCullingManager` to queue `ParticleRenderRequest` items and filter them by distance and frustum before invoking the provided `submit()` runnable, and added `ParticleCullingAPI.queueParticle(...)`.
- Wired the systems into `ClientModEvents` so `ParticleCullingManager.render(...)` is executed in the `AFTER_PARTICLES` render stage and `OverlayBatcher.render(...)` is executed during the overlay render hook via `ModdedRenderInterceptor`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963eb5f55b483288826257694277bc5)