### PR TITLE
Add render-distance mitigation support

### DIFF
--- a/src/main/java/com/thunder/novaapi/Core/NovaAPI.java
+++ b/src/main/java/com/thunder/novaapi/Core/NovaAPI.java
@@ -21,6 +21,7 @@ import com.thunder.novaapi.chunk.ChunkTickThrottler;
 import com.thunder.novaapi.command.*;
 import com.thunder.novaapi.config.ConfigRegistrationValidator;
 import com.thunder.novaapi.config.NovaAPIConfig;
+import com.thunder.novaapi.config.PerformanceMitigationConfig;
 import com.thunder.novaapi.io.BufferPool;
 import com.thunder.novaapi.io.IoExecutors;
 import com.thunder.novaapi.task.BackgroundTaskScheduler;
@@ -100,6 +101,9 @@ public class NovaAPI {
 
         ConfigRegistrationValidator.register(container, ModConfig.Type.COMMON, ChunkStreamingConfig.CONFIG_SPEC,
                 CONFIG_FOLDER + "novaapi-chunk-streaming.toml");
+
+        ConfigRegistrationValidator.register(container, ModConfig.Type.COMMON, PerformanceMitigationConfig.CONFIG_SPEC,
+                CONFIG_FOLDER + "novaapi-performance-mitigation.toml");
     }
 
     private void commonSetup(final FMLCommonSetupEvent event) {

--- a/src/main/java/com/thunder/novaapi/config/PerformanceMitigationConfig.java
+++ b/src/main/java/com/thunder/novaapi/config/PerformanceMitigationConfig.java
@@ -1,0 +1,75 @@
+package com.thunder.novaapi.config;
+
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+/**
+ * Common config entries for performance mitigation features.
+ */
+public final class PerformanceMitigationConfig {
+    public static final ModConfigSpec CONFIG_SPEC;
+
+    public static final ModConfigSpec.BooleanValue ENABLE_RENDER_DISTANCE_MITIGATION;
+    public static final ModConfigSpec.IntValue RENDER_DISTANCE_FPS_THRESHOLD_MS;
+    public static final ModConfigSpec.DoubleValue RENDER_DISTANCE_QUEUE_PRESSURE_THRESHOLD;
+    public static final ModConfigSpec.IntValue RENDER_DISTANCE_VIEW_DROP;
+    public static final ModConfigSpec.IntValue RENDER_DISTANCE_ENTITY_DROP;
+
+    private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
+
+    static {
+        BUILDER.push("performanceMitigation");
+        ENABLE_RENDER_DISTANCE_MITIGATION = BUILDER
+                .comment("Enable render-distance mitigation suggestions/actions.")
+                .define("enableRenderDistanceMitigation", true);
+        RENDER_DISTANCE_FPS_THRESHOLD_MS = BUILDER
+                .comment("Worst tick time (ms) treated as a render-distance spike.")
+                .defineInRange("renderDistanceFpsThresholdMs", 55, 20, 200);
+        RENDER_DISTANCE_QUEUE_PRESSURE_THRESHOLD = BUILDER
+                .comment("Chunk I/O queue saturation ratio that signals render queue pressure.")
+                .defineInRange("renderDistanceQueuePressureThreshold", 0.85D, 0.0D, 2.0D);
+        RENDER_DISTANCE_VIEW_DROP = BUILDER
+                .comment("Chunks to drop from client view distance during render-distance mitigation.")
+                .defineInRange("renderDistanceViewDrop", 2, 0, 16);
+        RENDER_DISTANCE_ENTITY_DROP = BUILDER
+                .comment("Chunks to drop from simulation/entity distance during render-distance mitigation.")
+                .defineInRange("renderDistanceEntityDrop", 1, 0, 16);
+        BUILDER.pop();
+
+        CONFIG_SPEC = BUILDER.build();
+    }
+
+    private PerformanceMitigationConfig() {
+    }
+
+    public static PerformanceMitigationValues values() {
+        try {
+            return new PerformanceMitigationValues(
+                    ENABLE_RENDER_DISTANCE_MITIGATION.get(),
+                    RENDER_DISTANCE_FPS_THRESHOLD_MS.get(),
+                    RENDER_DISTANCE_QUEUE_PRESSURE_THRESHOLD.get(),
+                    RENDER_DISTANCE_VIEW_DROP.get(),
+                    RENDER_DISTANCE_ENTITY_DROP.get()
+            );
+        } catch (IllegalStateException ex) {
+            return defaultValues();
+        }
+    }
+
+    public static PerformanceMitigationValues defaultValues() {
+        return new PerformanceMitigationValues(
+                ENABLE_RENDER_DISTANCE_MITIGATION.getDefault(),
+                RENDER_DISTANCE_FPS_THRESHOLD_MS.getDefault(),
+                RENDER_DISTANCE_QUEUE_PRESSURE_THRESHOLD.getDefault(),
+                RENDER_DISTANCE_VIEW_DROP.getDefault(),
+                RENDER_DISTANCE_ENTITY_DROP.getDefault()
+        );
+    }
+
+    public record PerformanceMitigationValues(
+            boolean renderDistanceEnabled,
+            int renderDistanceFpsThresholdMs,
+            double renderDistanceQueuePressureThreshold,
+            int renderDistanceViewDrop,
+            int renderDistanceEntityDrop
+    ) { }
+}


### PR DESCRIPTION
### Motivation
- Detect spikes that affect client rendering (high worst-tick time or render queue pressure) and surface them as a distinct `render-distance` subsystem load.
- Provide an automated, short-lived mitigation to reduce client view distance and entity/simulation distance to relieve render I/O and FPS pressure.
- Allow pack authors/operators to tune or disable the behavior via configuration thresholds.

### Description
- Add `PerformanceMitigationConfig` with toggles and thresholds and register it as `novaapi-performance-mitigation.toml` via `ConfigRegistrationValidator`.
- Extend `PerformanceAdvisor.observe` to compute render queue pressure and emit a `render-distance` `SubsystemLoad` when FPS or queue pressure exceeds configured thresholds, and add local advice in `suggestionFor`.
- Add proposal handling for the `render-distance` subsystem in `PerformanceMitigationController.buildActionsFromRequest` and an approval path that calls `applyRenderDistanceMitigation`.
- Implement `applyRenderDistanceMitigation`/`rollbackRenderDistance` logic to temporarily adjust `PlayerList` view distance and simulation distance with correct expiry and rollback behavior.

### Testing
- No automated tests were run for this change.
- Functional verification and CI build were not executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963eb636fa48328aabeaea4c1bebcf2)