### PR TITLE
Add chunk mesh scheduling with config limits

### DIFF
--- a/src/main/java/com/thunder/novaapi/chunk/ChunkMeshScheduler.java
+++ b/src/main/java/com/thunder/novaapi/chunk/ChunkMeshScheduler.java
@@ -1,0 +1,106 @@
+package com.thunder.novaapi.chunk;
+
+import com.thunder.novaapi.RenderEngine.Threading.RenderThreadManager;
+import com.thunder.novaapi.task.BackgroundTaskScheduler;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
+
+import java.util.Objects;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * Queues chunk mesh rebuilds on background workers and schedules GPU uploads on the render thread.
+ */
+public final class ChunkMeshScheduler {
+    private static final ConcurrentLinkedQueue<MeshRebuildRequest<?>> REBUILD_QUEUE = new ConcurrentLinkedQueue<>();
+    private static final ConcurrentLinkedQueue<Runnable> UPLOAD_QUEUE = new ConcurrentLinkedQueue<>();
+    private static final AtomicInteger IN_FLIGHT_REBUILDS = new AtomicInteger();
+    private static ChunkStreamingConfig.ChunkConfigValues config = ChunkStreamingConfig.values();
+
+    private ChunkMeshScheduler() {
+    }
+
+    public static void configure(ChunkStreamingConfig.ChunkConfigValues values) {
+        config = values;
+    }
+
+    public static void shutdown() {
+        REBUILD_QUEUE.clear();
+        UPLOAD_QUEUE.clear();
+        IN_FLIGHT_REBUILDS.set(0);
+    }
+
+    public static <T> void enqueue(ResourceKey<Level> dimension,
+                                   ChunkPos pos,
+                                   Supplier<T> rebuildWork,
+                                   Consumer<T> uploadWork) {
+        Objects.requireNonNull(dimension, "dimension");
+        Objects.requireNonNull(pos, "pos");
+        Objects.requireNonNull(rebuildWork, "rebuildWork");
+        Objects.requireNonNull(uploadWork, "uploadWork");
+        REBUILD_QUEUE.add(new MeshRebuildRequest<>(dimension, pos, rebuildWork, uploadWork));
+    }
+
+    public static void tick() {
+        int rebuildBudget = Math.max(0, config.maxMeshRebuildsPerTick());
+        for (int i = 0; i < rebuildBudget; i++) {
+            MeshRebuildRequest<?> request = REBUILD_QUEUE.poll();
+            if (request == null) {
+                break;
+            }
+            dispatchRebuild(request);
+        }
+
+        int uploadBudget = Math.max(0, config.meshUploadBatchSize());
+        for (int i = 0; i < uploadBudget; i++) {
+            Runnable upload = UPLOAD_QUEUE.poll();
+            if (upload == null) {
+                break;
+            }
+            RenderThreadManager.executeRenderTask(upload);
+        }
+    }
+
+    public static int inFlightRebuilds() {
+        return IN_FLIGHT_REBUILDS.get();
+    }
+
+    public static int pendingRebuilds() {
+        return REBUILD_QUEUE.size();
+    }
+
+    public static int pendingUploads() {
+        return UPLOAD_QUEUE.size();
+    }
+
+    private static <T> void dispatchRebuild(MeshRebuildRequest<T> request) {
+        IN_FLIGHT_REBUILDS.incrementAndGet();
+        BackgroundTaskScheduler.submit(request.dimension(), request.pos().toLong(), () -> {
+            T result = null;
+            try {
+                result = request.rebuildWork().get();
+            } finally {
+                IN_FLIGHT_REBUILDS.decrementAndGet();
+            }
+            enqueueUpload(() -> request.uploadWork().accept(result));
+        });
+    }
+
+    private static void enqueueUpload(Runnable uploadTask) {
+        if (uploadTask != null) {
+            UPLOAD_QUEUE.add(uploadTask);
+        }
+    }
+
+    private record MeshRebuildRequest<T>(
+            ResourceKey<Level> dimension,
+            ChunkPos pos,
+            Supplier<T> rebuildWork,
+            Consumer<T> uploadWork
+    ) {
+    }
+}

--- a/src/main/java/com/thunder/novaapi/chunk/ChunkStreamManager.java
+++ b/src/main/java/com/thunder/novaapi/chunk/ChunkStreamManager.java
@@ -70,6 +70,7 @@ public final class ChunkStreamManager {
         storageAdapter = adapter;
         BufferPool.configure(values);
         ChunkTickThrottler.configure(values);
+        ChunkMeshScheduler.configure(values);
         sliceCache = new ChunkSliceCache(values.sliceInternLimit());
         sliceCache.reset();
         STATE.clear();
@@ -90,6 +91,7 @@ public final class ChunkStreamManager {
         WARM_CACHE_MISSES.set(0L);
         WARM_CACHE.clear();
         HOT_CACHE.clear();
+        ChunkMeshScheduler.shutdown();
         ioController = new ChunkIoController(() -> config, () -> storageAdapter, null);
     }
 
@@ -176,6 +178,7 @@ public final class ChunkStreamManager {
         lastGameTime.set(gameTime);
         expireTickets(gameTime);
         ioController.tick(gameTime);
+        ChunkMeshScheduler.tick();
     }
 
     /**

--- a/src/main/java/com/thunder/novaapi/chunk/ChunkStreamingConfig.java
+++ b/src/main/java/com/thunder/novaapi/chunk/ChunkStreamingConfig.java
@@ -37,6 +37,8 @@ public final class ChunkStreamingConfig {
     public static final ModConfigSpec.IntValue DELTA_CHANGE_BUDGET;
     public static final ModConfigSpec.IntValue LIGHT_COMPRESSION_LEVEL;
     public static final ModConfigSpec.IntValue WRITE_FLUSH_INTERVAL_TICKS;
+    public static final ModConfigSpec.IntValue MAX_MESH_REBUILDS_PER_TICK;
+    public static final ModConfigSpec.IntValue MESH_UPLOAD_BATCH_SIZE;
     public static final ModConfigSpec.ConfigValue<String> CACHE_FOLDER_NAME;
     public static final ModConfigSpec.BooleanValue STORE_CACHE_IN_WORLD_CONFIG;
 
@@ -100,6 +102,10 @@ public final class ChunkStreamingConfig {
                 .defineInRange("lightCompressionLevel", 6, 1, 9);
         WRITE_FLUSH_INTERVAL_TICKS = BUILDER.comment("Interval (in ticks) to batch dirty chunk writes using the scheduled flush task.")
                 .defineInRange("writeFlushIntervalTicks", 20, 1, 200);
+        MAX_MESH_REBUILDS_PER_TICK = BUILDER.comment("Maximum chunk mesh rebuilds to start per tick.")
+                .defineInRange("maxMeshRebuildsPerTick", 4, 0, 64);
+        MESH_UPLOAD_BATCH_SIZE = BUILDER.comment("Maximum chunk mesh upload tasks to dispatch to the render thread per tick.")
+                .defineInRange("meshUploadBatchSize", 16, 0, 256);
         CACHE_FOLDER_NAME = BUILDER.comment("Folder name used for chunk cache storage.")
                 .define("cacheFolderName", "chunk-cache");
         STORE_CACHE_IN_WORLD_CONFIG = BUILDER.comment("If true, chunk cache data is stored under the world-specific config folder instead of the global config directory.")
@@ -143,6 +149,8 @@ public final class ChunkStreamingConfig {
                     DELTA_CHANGE_BUDGET.get(),
                     LIGHT_COMPRESSION_LEVEL.get(),
                     WRITE_FLUSH_INTERVAL_TICKS.get(),
+                    MAX_MESH_REBUILDS_PER_TICK.get(),
+                    MESH_UPLOAD_BATCH_SIZE.get(),
                     CACHE_FOLDER_NAME.get(),
                     STORE_CACHE_IN_WORLD_CONFIG.get()
             );
@@ -184,6 +192,8 @@ public final class ChunkStreamingConfig {
                 DELTA_CHANGE_BUDGET.getDefault(),
                 LIGHT_COMPRESSION_LEVEL.getDefault(),
                 WRITE_FLUSH_INTERVAL_TICKS.getDefault(),
+                MAX_MESH_REBUILDS_PER_TICK.getDefault(),
+                MESH_UPLOAD_BATCH_SIZE.getDefault(),
                 CACHE_FOLDER_NAME.getDefault(),
                 STORE_CACHE_IN_WORLD_CONFIG.getDefault()
         );
@@ -218,6 +228,8 @@ public final class ChunkStreamingConfig {
             int deltaChangeBudget,
             int lightCompressionLevel,
             int writeFlushIntervalTicks,
+            int maxMeshRebuildsPerTick,
+            int meshUploadBatchSize,
             String cacheFolderName,
             boolean storeCacheInWorldConfig
     ) {
@@ -260,6 +272,8 @@ public final class ChunkStreamingConfig {
                     256,
                     6,
                     20,
+                    4,
+                    16,
                     "chunk-cache",
                     true
             );


### PR DESCRIPTION
### Motivation
- Provide a lightweight scheduler to perform chunk mesh rebuilds off the main thread and limit their rate to avoid CPU spikes.
- Ensure GPU buffer uploads run on the proper render thread to avoid OpenGL/render-system threading issues.
- Expose tuning knobs to control how many rebuilds and upload tasks are processed per tick so server/mods can tune throughput.

### Description
- Add `ChunkMeshScheduler` which queues mesh rebuild requests, runs rebuild work via `BackgroundTaskScheduler`, and enqueues GPU uploads to be dispatched on the render thread using `RenderThreadManager.executeRenderTask`.
- Expose two new configuration entries `MAX_MESH_REBUILDS_PER_TICK` and `MESH_UPLOAD_BATCH_SIZE` in `ChunkStreamingConfig` and surface them via the `ChunkConfigValues` record.
- Wire the mesh scheduler lifecycle into `ChunkStreamManager` by calling `ChunkMeshScheduler.configure(values)` during `initialize`, calling `ChunkMeshScheduler.tick()` each `tick`, and invoking `ChunkMeshScheduler.shutdown()` on `shutdown`.
- Add inspection helpers in `ChunkMeshScheduler` (pending/in-flight counts) and use concurrent queues to separate rebuild and upload stages.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963eb6d5c208328b4b0d3e965099ea3)