### PR TITLE
Add LOD selection and per‑LOD VAO caching for instanced rendering

### DIFF
--- a/src/main/java/com/thunder/novaapi/RenderEngine/instancing/InstancedRenderer.java
+++ b/src/main/java/com/thunder/novaapi/RenderEngine/instancing/InstancedRenderer.java
@@ -1,26 +1,32 @@
 package com.thunder.novaapi.RenderEngine.instancing;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.culling.Frustum;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.Vec3;
 import org.lwjgl.opengl.GL30;
 import org.lwjgl.opengl.GL31;
 
 import java.util.*;
 
 public class InstancedRenderer {
+    private static final double LOD0_MAX_DISTANCE_SQR = 16.0 * 16.0;
+    private static final double LOD1_MAX_DISTANCE_SQR = 48.0 * 48.0;
 
     /**
      * Renders all visible entities using instanced rendering, grouped by model.
      */
     public static void renderAll(Iterable<Entity> entities, Frustum frustum) {
         Map<ResourceLocation, List<Entity>> batched = new HashMap<>();
+        Vec3 cameraPos = Minecraft.getInstance().gameRenderer.getMainCamera().getPosition();
 
         for (Entity entity : entities) {
             if (!frustum.isVisible(entity.getBoundingBox())) continue;
 
             ResourceLocation modelPath = ModelRegistryHelper.getModelPath(entity.getType());
-            batched.computeIfAbsent(modelPath, k -> new ArrayList<>()).add(entity);
+            ResourceLocation lodPath = ModelRegistryHelper.getLodModelPath(modelPath, selectLod(entity, cameraPos));
+            batched.computeIfAbsent(lodPath, k -> new ArrayList<>()).add(entity);
         }
 
         for (Map.Entry<ResourceLocation, List<Entity>> entry : batched.entrySet()) {
@@ -35,5 +41,16 @@ public class InstancedRenderer {
         }
 
         GL30.glBindVertexArray(0); // clean unbind
+    }
+
+    private static int selectLod(Entity entity, Vec3 cameraPos) {
+        double distanceSqr = entity.position().distanceToSqr(cameraPos);
+        if (distanceSqr <= LOD0_MAX_DISTANCE_SQR) {
+            return 0;
+        }
+        if (distanceSqr <= LOD1_MAX_DISTANCE_SQR) {
+            return 1;
+        }
+        return 2;
     }
 }

--- a/src/main/java/com/thunder/novaapi/RenderEngine/instancing/ModelRegistryHelper.java
+++ b/src/main/java/com/thunder/novaapi/RenderEngine/instancing/ModelRegistryHelper.java
@@ -43,4 +43,25 @@ public class ModelRegistryHelper {
         return entityModelMap.getOrDefault(type,
                 ResourceLocation.tryParse("minecraft:models/entity/default.json"));
     }
+
+    /**
+     * Returns a LOD-specific model path for the given EntityType.
+     * LOD 0 is the base model path, while higher LODs append "#lodX".
+     */
+    public static ResourceLocation getLodModelPath(EntityType<?> type, int lod) {
+        return getLodModelPath(getModelPath(type), lod);
+    }
+
+    /**
+     * Returns a LOD-specific model path for the given base model path.
+     * LOD 0 is the base model path, while higher LODs append "#lodX".
+     */
+    public static ResourceLocation getLodModelPath(ResourceLocation basePath, int lod) {
+        if (lod <= 0 || basePath == null) {
+            return basePath;
+        }
+
+        ResourceLocation lodPath = ResourceLocation.tryParse(basePath + "#lod" + lod);
+        return lodPath != null ? lodPath : basePath;
+    }
 }

--- a/src/main/java/com/thunder/novaapi/RenderEngine/instancing/VAOManager.java
+++ b/src/main/java/com/thunder/novaapi/RenderEngine/instancing/VAOManager.java
@@ -39,6 +39,15 @@ public class VAOManager {
     }
 
     /**
+     * Attempts to load a VAO for a LOD-specific model path.
+     * Each LOD level is cached separately per model.
+     */
+    public static int getOrLoadVAO(ResourceLocation baseModelPath, int lod) {
+        ResourceLocation lodPath = ModelRegistryHelper.getLodModelPath(baseModelPath, lod);
+        return getOrLoadVAO(lodPath);
+    }
+
+    /**
      * Tries to load a VAO from the given model file.
      * Replace this stub with actual model parsing logic (OBJ, JSON, etc).
      */
@@ -98,5 +107,13 @@ public class VAOManager {
      */
     public static boolean isModelEnabled(ResourceLocation path) {
         return !disabledModels.getOrDefault(path, false);
+    }
+
+    /**
+     * Checks if instanced rendering is enabled for a LOD-specific model path.
+     */
+    public static boolean isModelEnabled(ResourceLocation baseModelPath, int lod) {
+        ResourceLocation lodPath = ModelRegistryHelper.getLodModelPath(baseModelPath, lod);
+        return isModelEnabled(lodPath);
     }
 }


### PR DESCRIPTION
### Motivation
- Provide LOD variants for entity models (e.g., `model#lod1`) so lower-detail assets can be used at distance.
- Select the appropriate model LOD per-entity based on camera distance during instanced rendering to improve performance.
- Maintain per-model VAO caching but ensure different LODs do not conflict by caching VAOs per LOD.

### Description
- Added `ModelRegistryHelper.getLodModelPath(ResourceLocation, int)` and an `EntityType` overload to produce `#lodX` variants while falling back to the base path.
- Updated `InstancedRenderer.renderAll` to obtain the camera position, call a new `selectLod` helper to pick an LOD based on squared distance thresholds, and batch entities by LOD-specific `ResourceLocation` before drawing.
- Added `VAOManager.getOrLoadVAO(ResourceLocation, int)` and `VAOManager.isModelEnabled(ResourceLocation, int)` to cache and query VAOs per LOD while preserving the existing disabled-model logic.
- Existing behavior for fallback to vanilla/default models and error handling remains unchanged.

### Testing
- No automated tests were executed for this change.
- Code compiles were not run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963eb7779188328905c2f0a3945b8a8)