### PR TITLE
Add entity culling pre-pass for instanced rendering

### DIFF
--- a/src/main/java/com/thunder/novaapi/RenderEngine/ClientModEvents.java
+++ b/src/main/java/com/thunder/novaapi/RenderEngine/ClientModEvents.java
@@ -3,13 +3,17 @@ package com.thunder.novaapi.RenderEngine;
 
 import com.thunder.novaapi.Core.NovaAPI;
 import com.thunder.novaapi.RenderEngine.Threading.ModdedRenderInterceptor;
+import com.thunder.novaapi.RenderEngine.culling.EntityCullingManager;
 import com.thunder.novaapi.RenderEngine.instancing.InstancedRenderer;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.world.entity.Entity;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.client.event.RenderGuiLayerEvent;
 import net.neoforged.neoforge.client.event.RenderLevelStageEvent;
+
+import java.util.List;
 
 import static com.thunder.novaapi.Core.NovaAPI.MOD_ID;
 
@@ -21,8 +25,23 @@ public class ClientModEvents {
     public static void onRenderWorld(RenderLevelStageEvent event) {
         if (event.getStage() != RenderLevelStageEvent.Stage.AFTER_PARTICLES) return;
 
+        Minecraft minecraft = Minecraft.getInstance();
+        if (minecraft.level == null) return;
+
+        int renderDistanceChunks = minecraft.options.renderDistance().get();
+        double maxDistance = Math.max(16.0D, renderDistanceChunks * 16.0D);
+        double maxDistanceSq = maxDistance * maxDistance;
+
+        EntityCullingManager.beginFrame();
+        List<Entity> culledEntities = EntityCullingManager.cullEntities(
+                minecraft.level.entitiesForRendering(),
+                minecraft.level,
+                event.getCamera(),
+                maxDistanceSq
+        );
+
         InstancedRenderer.renderAll(
-                Minecraft.getInstance().level.entitiesForRendering(),
+                culledEntities,
                 event.getFrustum()
         );
     }

--- a/src/main/java/com/thunder/novaapi/RenderEngine/culling/EntityCullingManager.java
+++ b/src/main/java/com/thunder/novaapi/RenderEngine/culling/EntityCullingManager.java
@@ -1,0 +1,56 @@
+package com.thunder.novaapi.RenderEngine.culling;
+
+import com.thunder.novaapi.config.NovaAPIConfig;
+import it.unimi.dsi.fastutil.ints.Int2BooleanOpenHashMap;
+import net.minecraft.client.Camera;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.HitResult;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class EntityCullingManager {
+    private static final Int2BooleanOpenHashMap VISIBILITY_CACHE = new Int2BooleanOpenHashMap();
+
+    private EntityCullingManager() {
+    }
+
+    public static void beginFrame() {
+        VISIBILITY_CACHE.clear();
+    }
+
+    public static List<Entity> cullEntities(Iterable<Entity> entities, Level level, Camera camera, double maxDistanceSq) {
+        Vec3 cameraPos = camera.getPosition();
+        boolean occlusionEnabled = NovaAPIConfig.ENABLE_OCCLUSION_CULLING.get();
+        List<Entity> visibleEntities = new ArrayList<>();
+
+        for (Entity entity : entities) {
+            if (isEntityVisible(entity, level, cameraPos, maxDistanceSq, occlusionEnabled)) {
+                visibleEntities.add(entity);
+            }
+        }
+
+        return visibleEntities;
+    }
+
+    private static boolean isEntityVisible(Entity entity, Level level, Vec3 cameraPos, double maxDistanceSq, boolean occlusionEnabled) {
+        int entityId = entity.getId();
+        if (VISIBILITY_CACHE.containsKey(entityId)) {
+            return VISIBILITY_CACHE.get(entityId);
+        }
+
+        boolean visible = entity.distanceToSqr(cameraPos) <= maxDistanceSq;
+
+        if (visible && occlusionEnabled) {
+            Vec3 target = entity.getBoundingBox().getCenter();
+            HitResult hit = level.clip(new ClipContext(cameraPos, target, ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, entity));
+            visible = hit.getType() == HitResult.Type.MISS;
+        }
+
+        VISIBILITY_CACHE.put(entityId, visible);
+        return visible;
+    }
+}

--- a/src/main/java/com/thunder/novaapi/config/NovaAPIConfig.java
+++ b/src/main/java/com/thunder/novaapi/config/NovaAPIConfig.java
@@ -14,6 +14,9 @@ public class NovaAPIConfig {
     public static final ModConfigSpec.BooleanValue ASYNC_CHUNK_LOADING;
     public static final ModConfigSpec.BooleanValue SMART_CHUNK_RETENTION;
 
+    // 🔹 Render Culling Settings
+    public static final ModConfigSpec.BooleanValue ENABLE_OCCLUSION_CULLING;
+
     static {
         BUILDER.push("General Settings");
         ENABLE_NOVA_API = BUILDER
@@ -31,6 +34,12 @@ public class NovaAPIConfig {
         SMART_CHUNK_RETENTION = BUILDER
                 .comment("Keep frequently accessed chunks loaded for longer to prevent constant reloads.")
                 .define("smartChunkRetention", true);
+        BUILDER.pop();
+
+        BUILDER.push("Render Culling Settings");
+        ENABLE_OCCLUSION_CULLING = BUILDER
+                .comment("Enable occlusion culling for entity instanced rendering. Disable if compatibility issues arise.")
+                .define("enableOcclusionCulling", true);
         BUILDER.pop();
 
         CONFIG = BUILDER.build();


### PR DESCRIPTION
### Motivation
- Reduce CPU/GPU work by filtering entities before `InstancedRenderer.renderAll` is invoked.
- Avoid repeated visibility tests by caching per-entity visibility results for the current frame.
- Optionally skip occluded entities via raytraced occlusion checks to further reduce rendering cost.
- Provide a compatibility toggle so pack makers can disable occlusion culling if it causes issues.

### Description
- Add `RenderEngine.culling.EntityCullingManager` that caches visibility in an `Int2BooleanOpenHashMap` and performs distance checks and optional occlusion queries via `level.clip`.
- Hook the culling pre-pass into `ClientModEvents.onRenderWorld`, compute `maxDistance` from `minecraft.options.renderDistance()`, call `EntityCullingManager.cullEntities(...)`, and pass the resulting `List<Entity>` to `InstancedRenderer.renderAll`.
- Introduce `ENABLE_OCCLUSION_CULLING` in `NovaAPIConfig` to allow toggling occlusion checks at runtime.
- Use the event camera position for culling and clear the per-frame cache via `EntityCullingManager.beginFrame()` at the start of each render pass.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963eb7a481c832896b8fa22e34828bc)