### PR TITLE
Handle expected ThreadMonitor interruptions during shutdown

### DIFF
--- a/src/main/java/com/thunder/novaapi/utils/ThreadMonitor.java
+++ b/src/main/java/com/thunder/novaapi/utils/ThreadMonitor.java
@@ -24,7 +24,12 @@ public class ThreadMonitor {
                 try {
                     Thread.sleep(CHECK_INTERVAL_MS);
                 } catch (InterruptedException e) {
-                    NovaAPI.LOGGER.warn("Thread monitor interrupted", e);
+                    if (!running) {
+                        NovaAPI.LOGGER.info("Thread monitor interrupted during shutdown (expected).");
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+                    NovaAPI.LOGGER.warn("Thread monitor interrupted unexpectedly", e);
                 }
             }
         }, "Nova-ThreadMonitor");


### PR DESCRIPTION
### Motivation
- Prevent the thread monitor from treating shutdown interrupts as errors and provide a clearer log message when shutdown interrupts occur.
- Ensure the thread's interrupt flag is preserved and the monitor exits cleanly on shutdown.
- Keep unexpected interruptions logged as warnings for diagnostic visibility.

### Description
- Update the `InterruptedException` handler in `ThreadMonitor` to check the `running` flag and treat an interrupt during shutdown as expected by logging at `info` level.
- Call `Thread.currentThread().interrupt()` and `break` out of the monitor loop when shutdown is in progress to restore the interrupt status and stop monitoring.
- Preserve the previous behavior of logging unexpected interrupts as warnings and leave `stopMonitoring()` to set `running = false` and `interrupt()` the monitor thread.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696462efae8083288b44e87b7083ee1c)