### PR TITLE
Add configurable caps for pending chunk mesh rebuilds/uploads and fix client memory sampling cadence

### DIFF
--- a/src/main/java/com/thunder/novaapi/MemUtils/MemoryTrackerClient.java
+++ b/src/main/java/com/thunder/novaapi/MemUtils/MemoryTrackerClient.java
@@ -25,9 +25,7 @@ public class MemoryTrackerClient {
     public static void onClientTick(ClientTickEvent.Post event) {
         if (++tickCounter >= SAMPLE_INTERVAL) {
             tickCounter = 0;
-            if (++tickCounter % SAMPLE_INTERVAL == 0) {
-                MemoryUtils.recordPeakUsage();
-            }
+            MemoryUtils.recordPeakUsage();
         }
     }
 }

--- a/src/main/java/com/thunder/novaapi/chunk/ChunkStreamingConfig.java
+++ b/src/main/java/com/thunder/novaapi/chunk/ChunkStreamingConfig.java
@@ -39,6 +39,8 @@ public final class ChunkStreamingConfig {
     public static final ModConfigSpec.IntValue WRITE_FLUSH_INTERVAL_TICKS;
     public static final ModConfigSpec.IntValue MAX_MESH_REBUILDS_PER_TICK;
     public static final ModConfigSpec.IntValue MESH_UPLOAD_BATCH_SIZE;
+    public static final ModConfigSpec.IntValue MAX_PENDING_MESH_REBUILDS;
+    public static final ModConfigSpec.IntValue MAX_PENDING_MESH_UPLOADS;
     public static final ModConfigSpec.ConfigValue<String> CACHE_FOLDER_NAME;
     public static final ModConfigSpec.BooleanValue STORE_CACHE_IN_WORLD_CONFIG;
 
@@ -106,6 +108,10 @@ public final class ChunkStreamingConfig {
                 .defineInRange("maxMeshRebuildsPerTick", 4, 0, 64);
         MESH_UPLOAD_BATCH_SIZE = BUILDER.comment("Maximum chunk mesh upload tasks to dispatch to the render thread per tick.")
                 .defineInRange("meshUploadBatchSize", 16, 0, 256);
+        MAX_PENDING_MESH_REBUILDS = BUILDER.comment("Maximum queued chunk mesh rebuilds before new requests are skipped. Set to 0 for unlimited.")
+                .defineInRange("maxPendingMeshRebuilds", 2048, 0, 65536);
+        MAX_PENDING_MESH_UPLOADS = BUILDER.comment("Maximum queued chunk mesh uploads before new requests are skipped. Set to 0 for unlimited.")
+                .defineInRange("maxPendingMeshUploads", 4096, 0, 65536);
         CACHE_FOLDER_NAME = BUILDER.comment("Folder name used for chunk cache storage.")
                 .define("cacheFolderName", "chunk-cache");
         STORE_CACHE_IN_WORLD_CONFIG = BUILDER.comment("If true, chunk cache data is stored under the world-specific config folder instead of the global config directory.")
@@ -151,6 +157,8 @@ public final class ChunkStreamingConfig {
                     WRITE_FLUSH_INTERVAL_TICKS.get(),
                     MAX_MESH_REBUILDS_PER_TICK.get(),
                     MESH_UPLOAD_BATCH_SIZE.get(),
+                    MAX_PENDING_MESH_REBUILDS.get(),
+                    MAX_PENDING_MESH_UPLOADS.get(),
                     CACHE_FOLDER_NAME.get(),
                     STORE_CACHE_IN_WORLD_CONFIG.get()
             );
@@ -194,6 +202,8 @@ public final class ChunkStreamingConfig {
                 WRITE_FLUSH_INTERVAL_TICKS.getDefault(),
                 MAX_MESH_REBUILDS_PER_TICK.getDefault(),
                 MESH_UPLOAD_BATCH_SIZE.getDefault(),
+                MAX_PENDING_MESH_REBUILDS.getDefault(),
+                MAX_PENDING_MESH_UPLOADS.getDefault(),
                 CACHE_FOLDER_NAME.getDefault(),
                 STORE_CACHE_IN_WORLD_CONFIG.getDefault()
         );
@@ -230,6 +240,8 @@ public final class ChunkStreamingConfig {
             int writeFlushIntervalTicks,
             int maxMeshRebuildsPerTick,
             int meshUploadBatchSize,
+            int maxPendingMeshRebuilds,
+            int maxPendingMeshUploads,
             String cacheFolderName,
             boolean storeCacheInWorldConfig
     ) {
@@ -274,6 +286,8 @@ public final class ChunkStreamingConfig {
                     20,
                     4,
                     16,
+                    2048,
+                    4096,
                     "chunk-cache",
                     true
             );


### PR DESCRIPTION
### Motivation
- Prevent unbounded growth of queued chunk mesh work that can cause sustained low FPS in large modpacks while keeping existing rebuild/upload optimizations. 
- Correct the client-side memory sampling cadence so peak memory is recorded on the intended interval.

### Description
- Add two new config values `maxPendingMeshRebuilds` and `maxPendingMeshUploads` to `ChunkStreamingConfig` and expose them via `ChunkConfigValues` and defaults. 
- Introduce `PENDING_REBUILDS` and `PENDING_UPLOADS` `AtomicInteger` counters in `ChunkMeshScheduler` and use them to enforce the configured queue caps when queuing rebuilds and uploads. 
- Decrement pending counters when items are polled for processing, reset them on `shutdown`, and update `pendingRebuilds()`/`pendingUploads()` to return the counters. 
- Update `enqueueUpload` to respect `maxPendingMeshUploads` and drop uploads when the cap is reached to avoid overflowing the upload queue. 
- Fix `MemoryTrackerClient.onClientTick` to remove the redundant increment and call `MemoryUtils.recordPeakUsage()` once every `SAMPLE_INTERVAL` ticks.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967dcc4dd6c83288a39f8768d8146a1)