### PR TITLE
Add modpack resource profile tuning

### DIFF
--- a/src/main/java/com/thunder/novaapi/config/NovaAPIConfig.java
+++ b/src/main/java/com/thunder/novaapi/config/NovaAPIConfig.java
@@ -8,6 +8,7 @@ public class NovaAPIConfig {
 
     // 🔹 General Settings
     public static final ModConfigSpec.BooleanValue ENABLE_NOVA_API;
+    public static final ModConfigSpec.BooleanValue MODPACK_RESOURCE_PROFILE;
 
     // 🔹 Chunk Optimization Settings
     public static final ModConfigSpec.BooleanValue ENABLE_CHUNK_OPTIMIZATIONS;
@@ -22,6 +23,9 @@ public class NovaAPIConfig {
         ENABLE_NOVA_API = BUILDER
                 .comment("Enable Nova API. If false, all features are disabled.")
                 .define("enableNovaAPI", true);
+        MODPACK_RESOURCE_PROFILE = BUILDER
+                .comment("Enable modpack-friendly tuning to lower CPU and memory usage (auto-adjusts Nova API internal limits).")
+                .define("modpackResourceProfile", false);
         BUILDER.pop();
 
         BUILDER.push("Chunk Optimization Settings");


### PR DESCRIPTION
### Motivation
- Provide an optional "modpack" profile that automatically reduces Nova API internal resource usage for pack authors who want lower CPU and memory footprint. 
- Make the resource reductions opt-in via configuration so packs can enable conservative defaults without changing individual subsystem configs. 

### Description
- Add `modpackResourceProfile` boolean to the common config in `NovaAPIConfig.java` as `MODPACK_RESOURCE_PROFILE`.
- Introduce `resolveAsyncConfig()` and `resolveChunkConfig()` in `NovaAPI.java` to produce clamped, conservative `AsyncThreadingConfig.AsyncConfigValues` and `ChunkStreamingConfig.ChunkConfigValues` when the modpack profile is enabled.
- Replace direct uses of `AsyncThreadingConfig.values()` and `ChunkStreamingConfig.values()` during initialization/restarts with `resolveAsyncConfig()` and `resolveChunkConfig()` so the tuned values are applied at startup and on config reloads.
- The tunings clamp parameters such as thread counts, queue sizes, cache limits, IO parallelism and mesh upload/rebuild limits to lower values when `modpackResourceProfile` is `true`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69686f6ddd048328b3c6afdd12c91802)