### PR TITLE
Tune modpack performance profiles

### DIFF
--- a/src/main/java/com/thunder/novaapi/AI/AI_perf/PerformanceMitigationController.java
+++ b/src/main/java/com/thunder/novaapi/AI/AI_perf/PerformanceMitigationController.java
@@ -54,7 +54,7 @@ public final class PerformanceMitigationController {
         List<PerformanceAction> proposals = new ArrayList<>();
         List<PerformanceAction> rollbackProposals = new ArrayList<>();
         List<PerformanceAdvisoryRequest.SubsystemLoad> loads = request.subsystemLoads();
-        PerformanceMitigationConfig.PerformanceMitigationValues config = PerformanceMitigationConfig.values();
+        PerformanceMitigationConfig.PerformanceMitigationValues config = PerformanceMitigationConfig.effectiveValues();
         for (PerformanceAdvisoryRequest.SubsystemLoad load : loads) {
             if (load.observedValue() < MIN_SEVERITY_FOR_ACTION) {
                 continue;
@@ -144,7 +144,7 @@ public final class PerformanceMitigationController {
             case "entity-ticking" -> applyEntityTickThrottle(server, 3, action.getDurationSeconds());
             case "chunk-processing" -> applyChunkMitigation(server, 1, action.getDurationSeconds());
             case "render-distance" -> {
-                PerformanceMitigationConfig.PerformanceMitigationValues config = PerformanceMitigationConfig.values();
+                PerformanceMitigationConfig.PerformanceMitigationValues config = PerformanceMitigationConfig.effectiveValues();
                 applyRenderDistanceMitigation(
                         server,
                         config.renderDistanceViewDrop(),

--- a/src/main/java/com/thunder/novaapi/Core/NovaAPI.java
+++ b/src/main/java/com/thunder/novaapi/Core/NovaAPI.java
@@ -249,7 +249,7 @@ public class NovaAPI {
 
     private static AsyncThreadingConfig.AsyncConfigValues resolveAsyncConfig() {
         AsyncThreadingConfig.AsyncConfigValues base = AsyncThreadingConfig.values();
-        if (!NovaAPIConfig.MODPACK_RESOURCE_PROFILE.get()) {
+        if (!NovaAPIConfig.isModpackProfileEnabled()) {
             return base;
         }
         int hardwareThreads = Math.max(1, Runtime.getRuntime().availableProcessors());
@@ -269,7 +269,7 @@ public class NovaAPI {
 
     private static ChunkStreamingConfig.ChunkConfigValues resolveChunkConfig() {
         ChunkStreamingConfig.ChunkConfigValues base = ChunkStreamingConfig.values();
-        if (!NovaAPIConfig.MODPACK_RESOURCE_PROFILE.get()) {
+        if (!NovaAPIConfig.isModpackProfileEnabled()) {
             return base;
         }
         int hardwareThreads = Math.max(1, Runtime.getRuntime().availableProcessors());

--- a/src/main/java/com/thunder/novaapi/cache/ModDataCache.java
+++ b/src/main/java/com/thunder/novaapi/cache/ModDataCache.java
@@ -252,7 +252,7 @@ public final class ModDataCache {
         LOCK.readLock().lock();
         try {
             long totalSize = ENTRIES.values().stream().mapToLong(CacheEntry::size).sum();
-            return new CacheStats(ENTRIES.size(), totalSize, ModDataCacheConfig.getMaxCacheSizeBytes(), cacheEnabled,
+            return new CacheStats(ENTRIES.size(), totalSize, ModDataCacheConfig.getEffectiveMaxCacheSizeBytes(), cacheEnabled,
                     ImmutableMap.copyOf(ENTRIES));
         } finally {
             LOCK.readLock().unlock();
@@ -309,7 +309,7 @@ public final class ModDataCache {
     }
 
     private static void pruneExpiredEntries() {
-        Duration maxAge = ModDataCacheConfig.getMaxEntryAge();
+        Duration maxAge = ModDataCacheConfig.getEffectiveMaxEntryAge();
         if (maxAge.isZero() || maxAge.isNegative()) {
             return;
         }
@@ -330,7 +330,7 @@ public final class ModDataCache {
     }
 
     private static void enforceSizeLimit() {
-        long limit = ModDataCacheConfig.getMaxCacheSizeBytes();
+        long limit = ModDataCacheConfig.getEffectiveMaxCacheSizeBytes();
         if (limit <= 0) {
             return;
         }

--- a/src/main/java/com/thunder/novaapi/cache/ModDataCacheConfig.java
+++ b/src/main/java/com/thunder/novaapi/cache/ModDataCacheConfig.java
@@ -1,5 +1,6 @@
 package com.thunder.novaapi.cache;
 
+import com.thunder.novaapi.config.NovaAPIConfig;
 import net.neoforged.neoforge.common.ModConfigSpec;
 
 import java.time.Duration;
@@ -45,6 +46,21 @@ public final class ModDataCacheConfig {
     }
 
     /**
+     * Returns the effective maximum cache size in bytes after modpack tuning.
+     */
+    public static long getEffectiveMaxCacheSizeBytes() {
+        long baseLimit = getMaxCacheSizeBytes();
+        if (!NovaAPIConfig.isModpackProfileEnabled()) {
+            return baseLimit;
+        }
+        long modpackCap = 256L * 1024L * 1024L;
+        if (baseLimit <= 0) {
+            return modpackCap;
+        }
+        return Math.min(baseLimit, modpackCap);
+    }
+
+    /**
      * Returns the configured maximum age for cache entries.
      */
     public static Duration getMaxEntryAge() {
@@ -53,6 +69,21 @@ public final class ModDataCacheConfig {
             return Duration.ZERO;
         }
         return Duration.ofHours(hours);
+    }
+
+    /**
+     * Returns the effective maximum cache entry age after modpack tuning.
+     */
+    public static Duration getEffectiveMaxEntryAge() {
+        Duration baseAge = getMaxEntryAge();
+        if (!NovaAPIConfig.isModpackProfileEnabled()) {
+            return baseAge;
+        }
+        Duration modpackAge = Duration.ofHours(72);
+        if (baseAge.isZero() || baseAge.isNegative()) {
+            return modpackAge;
+        }
+        return baseAge.compareTo(modpackAge) > 0 ? modpackAge : baseAge;
     }
 
     /**

--- a/src/main/java/com/thunder/novaapi/config/NovaAPIConfig.java
+++ b/src/main/java/com/thunder/novaapi/config/NovaAPIConfig.java
@@ -48,4 +48,12 @@ public class NovaAPIConfig {
 
         CONFIG = BUILDER.build();
     }
+
+    public static boolean isModpackProfileEnabled() {
+        try {
+            return MODPACK_RESOURCE_PROFILE.get();
+        } catch (IllegalStateException ex) {
+            return MODPACK_RESOURCE_PROFILE.getDefault();
+        }
+    }
 }

--- a/src/main/java/com/thunder/novaapi/config/PerformanceMitigationConfig.java
+++ b/src/main/java/com/thunder/novaapi/config/PerformanceMitigationConfig.java
@@ -55,6 +55,22 @@ public final class PerformanceMitigationConfig {
         }
     }
 
+    public static PerformanceMitigationValues effectiveValues() {
+        PerformanceMitigationValues base = values();
+        if (!NovaAPIConfig.isModpackProfileEnabled()) {
+            return base;
+        }
+        int fpsThreshold = Math.min(base.renderDistanceFpsThresholdMs(), 50);
+        double queueThreshold = Math.min(base.renderDistanceQueuePressureThreshold(), 0.75D);
+        return new PerformanceMitigationValues(
+                base.renderDistanceEnabled(),
+                fpsThreshold,
+                queueThreshold,
+                base.renderDistanceViewDrop(),
+                base.renderDistanceEntityDrop()
+        );
+    }
+
     public static PerformanceMitigationValues defaultValues() {
         return new PerformanceMitigationValues(
                 ENABLE_RENDER_DISTANCE_MITIGATION.getDefault(),


### PR DESCRIPTION
### Motivation
- Reduce CPU/memory/disk pressure when the optional modpack tuning profile is enabled by applying conservative caps across async, chunk streaming, cache, and mitigation subsystems.

### Description
- Add `NovaAPIConfig.isModpackProfileEnabled()` and use it when resolving async and chunk streaming configuration to apply lower thread/queue/cache limits.
- Introduce `ModDataCacheConfig.getEffectiveMaxCacheSizeBytes()` and `getEffectiveMaxEntryAge()` and apply these effective values in `ModDataCache` for pruning/reporting to cap cache usage for modpacks.
- Add `PerformanceMitigationConfig.effectiveValues()` and switch `PerformanceMitigationController` to use the effective values so render-distance mitigation thresholds are more aggressive under the modpack profile.
- Updated call sites in `NovaAPI`, `ModDataCache`, and mitigation code to consistently use the modpack-aware helpers.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696be87f06748328b0eca65388ef6d43)