### PR TITLE
Harden instanced model loading and LOD selection

### DIFF
--- a/src/main/java/com/thunder/novaapi/RenderEngine/RenderEngineConfig.java
+++ b/src/main/java/com/thunder/novaapi/RenderEngine/RenderEngineConfig.java
@@ -7,6 +7,9 @@ public final class RenderEngineConfig {
     public static final ModConfigSpec.BooleanValue ENABLE_OVERLAY_BATCHING;
     public static final ModConfigSpec.BooleanValue ENABLE_PARTICLE_CULLING;
     public static final ModConfigSpec.IntValue PARTICLE_CULL_DISTANCE;
+    public static final ModConfigSpec.BooleanValue ENABLE_INSTANCED_RENDERING;
+    public static final ModConfigSpec.DoubleValue INSTANCED_LOD0_DISTANCE;
+    public static final ModConfigSpec.DoubleValue INSTANCED_LOD1_DISTANCE;
 
     static {
         ModConfigSpec.Builder builder = new ModConfigSpec.Builder();
@@ -26,6 +29,18 @@ public final class RenderEngineConfig {
                 .defineInRange("particleCullingDistance", 128, 0, 4096);
         builder.pop();
 
+        builder.push("Instanced Rendering");
+        ENABLE_INSTANCED_RENDERING = builder
+                .comment("Enable instanced rendering for supported entity models.")
+                .define("enableInstancedRendering", true);
+        INSTANCED_LOD0_DISTANCE = builder
+                .comment("Distance in blocks for LOD0 instanced models.")
+                .defineInRange("instancedLod0Distance", 16.0D, 1.0D, 256.0D);
+        INSTANCED_LOD1_DISTANCE = builder
+                .comment("Distance in blocks for LOD1 instanced models.")
+                .defineInRange("instancedLod1Distance", 48.0D, 1.0D, 512.0D);
+        builder.pop();
+
         CONFIG_SPEC = builder.build();
     }
 
@@ -42,5 +57,17 @@ public final class RenderEngineConfig {
 
     public static int getParticleCullingDistance() {
         return PARTICLE_CULL_DISTANCE.get();
+    }
+
+    public static boolean isInstancedRenderingEnabled() {
+        return ENABLE_INSTANCED_RENDERING.get();
+    }
+
+    public static double getInstancedLod0Distance() {
+        return INSTANCED_LOD0_DISTANCE.get();
+    }
+
+    public static double getInstancedLod1Distance() {
+        return INSTANCED_LOD1_DISTANCE.get();
     }
 }

--- a/src/main/java/com/thunder/novaapi/resourcepack/ResourcePackManager.java
+++ b/src/main/java/com/thunder/novaapi/resourcepack/ResourcePackManager.java
@@ -181,7 +181,6 @@ public final class ResourcePackManager {
                     metadata.overlays(), metadata.isHidden());
         }
         return new Pack(locationInfo, supplier, metadata, selectionConfig);
-        return Pack.readMetaAndCreate(locationInfo, supplier, packType, selectionConfig);
     }
 
     private static PackSource createPackSource() {


### PR DESCRIPTION
### Motivation
- Prevent instanced rendering from trying to load null or placeholder model paths and improve observability when loading fails.
- Provide a way to override model paths at runtime to help mixins/resource-pack compatibility and mod interoperability.
- Make LOD selection more robust by clamping and using configurable distances so incorrect LOD choices or extra VAO loads are avoided.

### Description
- Introduced `DEFAULT_MODEL_PATH`, cleared and safely populated `entityModelMap` in `ModelRegistryHelper.initialize()`, and added `registerModelPath` and `isDefaultModel` to allow overrides and detect placeholder models.
- Hardened `VAOManager` to return early on `null` paths, skip the default placeholder model, mark failing models as disabled, and replace `System.err`/`println` with `NovaAPI.LOGGER` calls.
- Updated `InstancedRenderer` to early-return when `RenderEngineConfig.isInstancedRenderingEnabled()` is `false`, tolerate a `null` `Frustum`, compute clamped squared LOD thresholds via `resolveLodThresholds(...)`, use those thresholds in `selectLod`, and skip entities whose models are disabled or missing.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697104e0d2c4832896fbacba5c69e369)