### PR TITLE
Add adaptive systems framework and initial monitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,4 @@ NeoForged Discord: https://discord.neoforged.net/
 Performance and Memory Guidelines:
 =====================
 See [Memory and Performance Guidelines](docs/memory-and-performance-guidelines.md) for NovaAPI-specific recommendations to avoid leaks and keep NeoForge mods efficient.
+See [Adaptive Systems Blueprint](docs/adaptive-systems.md) for feature-scale optimization systems with built-in safety guardrails.

--- a/docs/adaptive-systems.md
+++ b/docs/adaptive-systems.md
@@ -1,0 +1,55 @@
+# Adaptive Systems Blueprint (NovaAPI)
+
+This document outlines the adaptive systems layer that adds **feature-scale gameplay intelligence** while staying guarded by safety budgets. Each system ties into Minecraft simulation data and is capped by sampling limits, tick budgets, and memory pressure checks.
+
+## Safety Guardrails (applies to all systems)
+- **Global budget gate:** Systems only run when tick time and free memory are within safe thresholds.
+- **Sampling budget:** Each tick has a shared sample limit so we do not introduce sudden lag spikes.
+- **Cooldown fallback:** If a safety threshold is exceeded, systems enter a cooldown period instead of pushing harder.
+- **Data caps + TTL:** Every per-dimension cache is size-bounded and expires old entries.
+
+## Feature Systems
+
+### 1) Region Intelligence
+Tracks player-driven activity per chunk to build a heat map of “alive” regions and a decay map for inactive regions.  
+**Use cases:** smart chunk retention, activity heatmap overlays, better region tooling.
+
+### 2) Mob Ecology & Population Pressure
+Samples mob density around players and aggregates by biome to identify overcrowding or starvation zones.  
+**Use cases:** smarter spawn balancing, biome health readouts, dynamic migration events.
+
+### 3) Redstone Load Monitor
+Monitors scheduled tick load (block + fluid tick queues) to detect hotspots or abnormal update pressure.  
+**Use cases:** redstone lag diagnostics, circuit heatmaps.
+
+### 4) Logistics Network Monitor
+Samples item entity pressure near players to quantify transport load (hoppers, item lines, storage bases).  
+**Use cases:** storage network advisories, logistics throttling hints.
+
+### 5) Chunk-Aware AI Scheduler
+Tracks mob density around players to inform AI throttling or chunk-level simulation pacing.  
+**Use cases:** AI work budgeting, off-screen optimization.
+
+### 6) Structure Activity Index
+Maintains a lightweight index of recently loaded chunks as structure/feature candidates.  
+**Use cases:** fast structure lookup and explorer tools without scanning entire worlds.
+
+### 7) Dynamic Weather Scheduler
+Tracks weather rhythm by dimension to enable biome-aware weather rules and event scheduling.  
+**Use cases:** storm events tied to biome heat, crop growth modifiers, travel hazards.
+
+### 8) Simulation Density Bands
+Builds a player-density snapshot at near/mid/far ranges to guide simulation scaling.  
+**Use cases:** dynamic simulation radius with player-count awareness.
+
+### 9) Inventory Heat Tracking
+Tracks frequently accessed container locations to identify hot storage areas.  
+**Use cases:** storage caching, smart sorting, or “hot access” overlays.
+
+### 10) Entity Sleep Monitor
+Tracks idle entities and classifies potential sleep candidates (based on movement + idle time).  
+**Use cases:** sleep state features with low risk of impacting active gameplay.
+
+## Config + Safety Notes
+All systems can be toggled individually, and the adaptive layer exposes a master switch, sampling intervals, and safety budgets for memory/tick time.  
+If any guardrail triggers, the system layer backs off automatically rather than amplifying load.

--- a/docs/adaptive-systems.md
+++ b/docs/adaptive-systems.md
@@ -52,4 +52,5 @@ Tracks idle entities and classifies potential sleep candidates (based on movemen
 
 ## Config + Safety Notes
 All systems can be toggled individually, and the adaptive layer exposes a master switch, sampling intervals, and safety budgets for memory/tick time.  
+The current adaptive systems are telemetry-only and do not mutate gameplay state.  
 If any guardrail triggers, the system layer backs off automatically rather than amplifying load.

--- a/src/main/java/com/thunder/novaapi/config/AdaptiveSystemsConfig.java
+++ b/src/main/java/com/thunder/novaapi/config/AdaptiveSystemsConfig.java
@@ -1,0 +1,187 @@
+package com.thunder.novaapi.config;
+
+import net.neoforged.neoforge.common.ModConfigSpec;
+
+public final class AdaptiveSystemsConfig {
+    public static final ModConfigSpec CONFIG_SPEC;
+
+    public static final ModConfigSpec.BooleanValue ENABLE_ADAPTIVE_SYSTEMS;
+    public static final ModConfigSpec.BooleanValue ENABLE_REGION_INTELLIGENCE;
+    public static final ModConfigSpec.BooleanValue ENABLE_MOB_ECOLOGY;
+    public static final ModConfigSpec.BooleanValue ENABLE_REDSTONE_LOAD_MONITOR;
+    public static final ModConfigSpec.BooleanValue ENABLE_LOGISTICS_NETWORK_MONITOR;
+    public static final ModConfigSpec.BooleanValue ENABLE_CHUNK_AWARE_AI_SCHEDULER;
+    public static final ModConfigSpec.BooleanValue ENABLE_STRUCTURE_INDEX;
+    public static final ModConfigSpec.BooleanValue ENABLE_DYNAMIC_WEATHER_SCHEDULER;
+    public static final ModConfigSpec.BooleanValue ENABLE_SIMULATION_DENSITY_SCALER;
+    public static final ModConfigSpec.BooleanValue ENABLE_INVENTORY_HEAT_TRACKING;
+    public static final ModConfigSpec.BooleanValue ENABLE_ENTITY_SLEEP_MONITOR;
+
+    public static final ModConfigSpec.IntValue SAMPLE_INTERVAL_TICKS;
+    public static final ModConfigSpec.IntValue MAX_SAMPLES_PER_TICK;
+
+    public static final ModConfigSpec.IntValue SAFETY_TICK_BUDGET_MS;
+    public static final ModConfigSpec.IntValue SAFETY_MIN_FREE_MEMORY_MB;
+    public static final ModConfigSpec.IntValue SAFETY_COOLDOWN_TICKS;
+
+    public static final ModConfigSpec.IntValue MAX_TRACKED_CHUNKS;
+    public static final ModConfigSpec.IntValue CHUNK_ACTIVITY_TTL_TICKS;
+    public static final ModConfigSpec.IntValue ENTITY_IDLE_TICKS;
+
+    private static final ModConfigSpec.Builder BUILDER = new ModConfigSpec.Builder();
+
+    static {
+        BUILDER.push("adaptiveSystems");
+        ENABLE_ADAPTIVE_SYSTEMS = BUILDER
+                .comment("Master switch for adaptive systems features.")
+                .define("enableAdaptiveSystems", true);
+
+        BUILDER.push("systems");
+        ENABLE_REGION_INTELLIGENCE = BUILDER
+                .comment("Track per-region activity and heat maps.")
+                .define("enableRegionIntelligence", true);
+        ENABLE_MOB_ECOLOGY = BUILDER
+                .comment("Track biome population pressure and mob ecology signals.")
+                .define("enableMobEcology", true);
+        ENABLE_REDSTONE_LOAD_MONITOR = BUILDER
+                .comment("Monitor redstone activity and hotspots.")
+                .define("enableRedstoneLoadMonitor", true);
+        ENABLE_LOGISTICS_NETWORK_MONITOR = BUILDER
+                .comment("Track item transport pressure near players.")
+                .define("enableLogisticsNetworkMonitor", true);
+        ENABLE_CHUNK_AWARE_AI_SCHEDULER = BUILDER
+                .comment("Track AI density around players for chunk-aware scheduling.")
+                .define("enableChunkAwareAiScheduler", true);
+        ENABLE_STRUCTURE_INDEX = BUILDER
+                .comment("Maintain a lightweight structure activity index.")
+                .define("enableStructureIndex", true);
+        ENABLE_DYNAMIC_WEATHER_SCHEDULER = BUILDER
+                .comment("Track weather rhythms and environmental pressure.")
+                .define("enableDynamicWeatherScheduler", true);
+        ENABLE_SIMULATION_DENSITY_SCALER = BUILDER
+                .comment("Track simulation density bands around players.")
+                .define("enableSimulationDensityScaler", true);
+        ENABLE_INVENTORY_HEAT_TRACKING = BUILDER
+                .comment("Track frequently accessed storage positions.")
+                .define("enableInventoryHeatTracking", true);
+        ENABLE_ENTITY_SLEEP_MONITOR = BUILDER
+                .comment("Track idle entity populations and safe sleep candidates.")
+                .define("enableEntitySleepMonitor", true);
+        BUILDER.pop();
+
+        BUILDER.push("sampling");
+        SAMPLE_INTERVAL_TICKS = BUILDER
+                .comment("Base sampling interval for adaptive systems.")
+                .defineInRange("sampleIntervalTicks", 200, 20, 2400);
+        MAX_SAMPLES_PER_TICK = BUILDER
+                .comment("Maximum samples performed per tick across adaptive systems.")
+                .defineInRange("maxSamplesPerTick", 128, 16, 2048);
+        BUILDER.pop();
+
+        BUILDER.push("safety");
+        SAFETY_TICK_BUDGET_MS = BUILDER
+                .comment("Max tick time before adaptive systems enter cooldown.")
+                .defineInRange("safetyTickBudgetMs", 45, 15, 200);
+        SAFETY_MIN_FREE_MEMORY_MB = BUILDER
+                .comment("Minimum free memory before adaptive systems enter cooldown.")
+                .defineInRange("safetyMinFreeMemoryMb", 512, 128, 32768);
+        SAFETY_COOLDOWN_TICKS = BUILDER
+                .comment("Cooldown ticks after a safety trip.")
+                .defineInRange("safetyCooldownTicks", 600, 40, 72000);
+        BUILDER.pop();
+
+        BUILDER.push("limits");
+        MAX_TRACKED_CHUNKS = BUILDER
+                .comment("Maximum number of tracked chunks per dimension for adaptive systems.")
+                .defineInRange("maxTrackedChunks", 4096, 256, 65536);
+        CHUNK_ACTIVITY_TTL_TICKS = BUILDER
+                .comment("Ticks before inactive chunk activity data expires.")
+                .defineInRange("chunkActivityTtlTicks", 24000, 600, 240000);
+        ENTITY_IDLE_TICKS = BUILDER
+                .comment("Ticks before entities are considered idle candidates.")
+                .defineInRange("entityIdleTicks", 1200, 100, 240000);
+        BUILDER.pop();
+
+        BUILDER.pop();
+
+        CONFIG_SPEC = BUILDER.build();
+    }
+
+    private AdaptiveSystemsConfig() {
+    }
+
+    public static AdaptiveSystemsValues values() {
+        try {
+            return new AdaptiveSystemsValues(
+                    ENABLE_ADAPTIVE_SYSTEMS.get(),
+                    ENABLE_REGION_INTELLIGENCE.get(),
+                    ENABLE_MOB_ECOLOGY.get(),
+                    ENABLE_REDSTONE_LOAD_MONITOR.get(),
+                    ENABLE_LOGISTICS_NETWORK_MONITOR.get(),
+                    ENABLE_CHUNK_AWARE_AI_SCHEDULER.get(),
+                    ENABLE_STRUCTURE_INDEX.get(),
+                    ENABLE_DYNAMIC_WEATHER_SCHEDULER.get(),
+                    ENABLE_SIMULATION_DENSITY_SCALER.get(),
+                    ENABLE_INVENTORY_HEAT_TRACKING.get(),
+                    ENABLE_ENTITY_SLEEP_MONITOR.get(),
+                    SAMPLE_INTERVAL_TICKS.get(),
+                    MAX_SAMPLES_PER_TICK.get(),
+                    SAFETY_TICK_BUDGET_MS.get(),
+                    SAFETY_MIN_FREE_MEMORY_MB.get(),
+                    SAFETY_COOLDOWN_TICKS.get(),
+                    MAX_TRACKED_CHUNKS.get(),
+                    CHUNK_ACTIVITY_TTL_TICKS.get(),
+                    ENTITY_IDLE_TICKS.get()
+            );
+        } catch (IllegalStateException ex) {
+            return defaultValues();
+        }
+    }
+
+    public static AdaptiveSystemsValues defaultValues() {
+        return new AdaptiveSystemsValues(
+                ENABLE_ADAPTIVE_SYSTEMS.getDefault(),
+                ENABLE_REGION_INTELLIGENCE.getDefault(),
+                ENABLE_MOB_ECOLOGY.getDefault(),
+                ENABLE_REDSTONE_LOAD_MONITOR.getDefault(),
+                ENABLE_LOGISTICS_NETWORK_MONITOR.getDefault(),
+                ENABLE_CHUNK_AWARE_AI_SCHEDULER.getDefault(),
+                ENABLE_STRUCTURE_INDEX.getDefault(),
+                ENABLE_DYNAMIC_WEATHER_SCHEDULER.getDefault(),
+                ENABLE_SIMULATION_DENSITY_SCALER.getDefault(),
+                ENABLE_INVENTORY_HEAT_TRACKING.getDefault(),
+                ENABLE_ENTITY_SLEEP_MONITOR.getDefault(),
+                SAMPLE_INTERVAL_TICKS.getDefault(),
+                MAX_SAMPLES_PER_TICK.getDefault(),
+                SAFETY_TICK_BUDGET_MS.getDefault(),
+                SAFETY_MIN_FREE_MEMORY_MB.getDefault(),
+                SAFETY_COOLDOWN_TICKS.getDefault(),
+                MAX_TRACKED_CHUNKS.getDefault(),
+                CHUNK_ACTIVITY_TTL_TICKS.getDefault(),
+                ENTITY_IDLE_TICKS.getDefault()
+        );
+    }
+
+    public record AdaptiveSystemsValues(
+            boolean enableAdaptiveSystems,
+            boolean enableRegionIntelligence,
+            boolean enableMobEcology,
+            boolean enableRedstoneLoadMonitor,
+            boolean enableLogisticsNetworkMonitor,
+            boolean enableChunkAwareAiScheduler,
+            boolean enableStructureIndex,
+            boolean enableDynamicWeatherScheduler,
+            boolean enableSimulationDensityScaler,
+            boolean enableInventoryHeatTracking,
+            boolean enableEntitySleepMonitor,
+            int sampleIntervalTicks,
+            int maxSamplesPerTick,
+            int safetyTickBudgetMs,
+            int safetyMinFreeMemoryMb,
+            int safetyCooldownTicks,
+            int maxTrackedChunks,
+            int chunkActivityTtlTicks,
+            int entityIdleTicks
+    ) {
+    }
+}

--- a/src/main/java/com/thunder/novaapi/systems/AdaptiveSystem.java
+++ b/src/main/java/com/thunder/novaapi/systems/AdaptiveSystem.java
@@ -1,0 +1,12 @@
+package com.thunder.novaapi.systems;
+
+import com.thunder.novaapi.config.AdaptiveSystemsConfig;
+import net.minecraft.server.MinecraftServer;
+
+public interface AdaptiveSystem {
+    String id();
+
+    boolean isEnabled(AdaptiveSystemsConfig.AdaptiveSystemsValues config);
+
+    void tick(MinecraftServer server, SafetyContext context);
+}

--- a/src/main/java/com/thunder/novaapi/systems/AdaptiveSystemsManager.java
+++ b/src/main/java/com/thunder/novaapi/systems/AdaptiveSystemsManager.java
@@ -1,0 +1,85 @@
+package com.thunder.novaapi.systems;
+
+import com.thunder.novaapi.config.AdaptiveSystemsConfig;
+import net.minecraft.server.MinecraftServer;
+import net.neoforged.neoforge.common.NeoForge;
+
+import java.util.List;
+
+public class AdaptiveSystemsManager {
+    private final List<AdaptiveSystem> systems = List.of(
+            new RegionIntelligenceSystem(),
+            new MobEcologyBalancerSystem(),
+            new RedstoneLoadMonitorSystem(),
+            new LogisticsNetworkMonitorSystem(),
+            new ChunkAwareAiSchedulerSystem(),
+            new StructureIndexSystem(),
+            new DynamicWeatherSchedulerSystem(),
+            new SimulationDensitySystem(),
+            new InventoryHeatSystem(),
+            new EntitySleepMonitorSystem()
+    );
+    private final SafetyMonitor safetyMonitor = new SafetyMonitor();
+    private long tickCounter = 0L;
+    private long cooldownUntilTick = 0L;
+    private boolean active = false;
+    private boolean eventsRegistered = false;
+
+    public void onServerStarting() {
+        active = true;
+        registerEvents();
+    }
+
+    public void onServerStopping() {
+        active = false;
+        cooldownUntilTick = 0L;
+    }
+
+    public void tick(MinecraftServer server) {
+        if (!active) {
+            return;
+        }
+        AdaptiveSystemsConfig.AdaptiveSystemsValues config = AdaptiveSystemsConfig.values();
+        if (!config.enableAdaptiveSystems()) {
+            return;
+        }
+
+        SafetyMonitor.SafetySnapshot snapshot = safetyMonitor.sample(config);
+        if (snapshot.overTickBudget() || snapshot.memoryPressure()) {
+            cooldownUntilTick = Math.max(cooldownUntilTick, tickCounter + config.safetyCooldownTicks());
+        }
+        boolean cooldownActive = tickCounter < cooldownUntilTick;
+        SampleBudget budget = new SampleBudget(config.maxSamplesPerTick());
+
+        SafetyContext context = new SafetyContext(
+                config,
+                budget,
+                tickCounter,
+                snapshot.tickTimeMs(),
+                snapshot.usedMemoryMb(),
+                snapshot.maxMemoryMb(),
+                snapshot.freeMemoryMb(),
+                snapshot.overTickBudget(),
+                snapshot.memoryPressure(),
+                cooldownActive
+        );
+
+        for (AdaptiveSystem system : systems) {
+            if (!system.isEnabled(config)) {
+                continue;
+            }
+            system.tick(server, context);
+        }
+        tickCounter++;
+    }
+
+    private void registerEvents() {
+        if (eventsRegistered) {
+            return;
+        }
+        for (AdaptiveSystem system : systems) {
+            NeoForge.EVENT_BUS.register(system);
+        }
+        eventsRegistered = true;
+    }
+}

--- a/src/main/java/com/thunder/novaapi/systems/ChunkAwareAiSchedulerSystem.java
+++ b/src/main/java/com/thunder/novaapi/systems/ChunkAwareAiSchedulerSystem.java
@@ -1,0 +1,48 @@
+package com.thunder.novaapi.systems;
+
+import com.thunder.novaapi.config.AdaptiveSystemsConfig;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.level.Level;
+
+public class ChunkAwareAiSchedulerSystem implements AdaptiveSystem {
+    private static final double SAMPLE_RADIUS = 40.0D;
+    private final Object2IntOpenHashMap<ResourceKey<Level>> aiDensity = new Object2IntOpenHashMap<>();
+
+    @Override
+    public String id() {
+        return "chunk_aware_ai_scheduler";
+    }
+
+    @Override
+    public boolean isEnabled(AdaptiveSystemsConfig.AdaptiveSystemsValues config) {
+        return config.enableChunkAwareAiScheduler();
+    }
+
+    @Override
+    public void tick(MinecraftServer server, SafetyContext context) {
+        if (!context.allowWork()) {
+            return;
+        }
+        if (context.tickCounter() % context.config().sampleIntervalTicks() != 0) {
+            return;
+        }
+
+        aiDensity.clear();
+        for (ServerLevel level : server.getAllLevels()) {
+            ResourceKey<Level> dimension = level.dimension();
+            int density = 0;
+            for (ServerPlayer player : level.players()) {
+                if (!context.sampleBudget().tryConsume(1)) {
+                    return;
+                }
+                density = Math.max(density, level.getEntitiesOfClass(Mob.class, player.getBoundingBox().inflate(SAMPLE_RADIUS)).size());
+            }
+            aiDensity.put(dimension, density);
+        }
+    }
+}

--- a/src/main/java/com/thunder/novaapi/systems/DynamicWeatherSchedulerSystem.java
+++ b/src/main/java/com/thunder/novaapi/systems/DynamicWeatherSchedulerSystem.java
@@ -1,0 +1,51 @@
+package com.thunder.novaapi.systems;
+
+import com.thunder.novaapi.config.AdaptiveSystemsConfig;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
+
+public class DynamicWeatherSchedulerSystem implements AdaptiveSystem {
+    private final Object2ObjectOpenHashMap<ResourceKey<Level>, WeatherState> weatherState = new Object2ObjectOpenHashMap<>();
+
+    @Override
+    public String id() {
+        return "dynamic_weather_scheduler";
+    }
+
+    @Override
+    public boolean isEnabled(AdaptiveSystemsConfig.AdaptiveSystemsValues config) {
+        return config.enableDynamicWeatherScheduler();
+    }
+
+    @Override
+    public void tick(MinecraftServer server, SafetyContext context) {
+        if (!context.allowWork()) {
+            return;
+        }
+        if (context.tickCounter() % context.config().sampleIntervalTicks() != 0) {
+            return;
+        }
+        if (!context.sampleBudget().tryConsume(1)) {
+            return;
+        }
+
+        for (ServerLevel level : server.getAllLevels()) {
+            ResourceKey<Level> dimension = level.dimension();
+            WeatherState state = weatherState.getOrDefault(dimension, new WeatherState(false, false, level.getGameTime(), 0L));
+            boolean raining = level.isRaining();
+            boolean thundering = level.isThundering();
+            long now = level.getGameTime();
+            if (state.isRaining() != raining || state.isThundering() != thundering) {
+                long lastDuration = now - state.lastChangeTick();
+                state = new WeatherState(raining, thundering, now, lastDuration);
+            }
+            weatherState.put(dimension, state);
+        }
+    }
+
+    private record WeatherState(boolean isRaining, boolean isThundering, long lastChangeTick, long lastDurationTicks) {
+    }
+}

--- a/src/main/java/com/thunder/novaapi/systems/EntitySleepMonitorSystem.java
+++ b/src/main/java/com/thunder/novaapi/systems/EntitySleepMonitorSystem.java
@@ -1,7 +1,9 @@
 package com.thunder.novaapi.systems;
 
 import com.thunder.novaapi.config.AdaptiveSystemsConfig;
+import it.unimi.dsi.fastutil.ints.Int2LongMap;
 import it.unimi.dsi.fastutil.ints.Int2LongOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectIterator;
 import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.resources.ResourceKey;
@@ -10,9 +12,6 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Mob;
 import net.minecraft.world.level.Level;
-
-import java.util.Iterator;
-import java.util.Map;
 
 public class EntitySleepMonitorSystem implements AdaptiveSystem {
     private static final double SAMPLE_RADIUS = 48.0D;
@@ -56,10 +55,10 @@ public class EntitySleepMonitorSystem implements AdaptiveSystem {
             }
 
             int idle = 0;
-            Iterator<Map.Entry<Integer, Long>> iterator = lastActive.int2LongEntrySet().iterator();
+            ObjectIterator<Int2LongMap.Entry> iterator = lastActive.int2LongEntrySet().iterator();
             while (iterator.hasNext()) {
-                Map.Entry<Integer, Long> entry = iterator.next();
-                if (now - entry.getValue() > context.config().entityIdleTicks()) {
+                Int2LongMap.Entry entry = iterator.next();
+                if (now - entry.getLongValue() > context.config().entityIdleTicks()) {
                     idle++;
                 }
                 if (lastActive.size() > context.config().maxTrackedChunks()) {

--- a/src/main/java/com/thunder/novaapi/systems/EntitySleepMonitorSystem.java
+++ b/src/main/java/com/thunder/novaapi/systems/EntitySleepMonitorSystem.java
@@ -1,0 +1,72 @@
+package com.thunder.novaapi.systems;
+
+import com.thunder.novaapi.config.AdaptiveSystemsConfig;
+import it.unimi.dsi.fastutil.ints.Int2LongOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.level.Level;
+
+import java.util.Iterator;
+import java.util.Map;
+
+public class EntitySleepMonitorSystem implements AdaptiveSystem {
+    private static final double SAMPLE_RADIUS = 48.0D;
+    private static final double ACTIVE_MOVEMENT_THRESHOLD = 0.0025D;
+
+    private final Object2ObjectOpenHashMap<ResourceKey<Level>, Int2LongOpenHashMap> lastActiveTick = new Object2ObjectOpenHashMap<>();
+    private final Object2IntOpenHashMap<ResourceKey<Level>> idleCounts = new Object2IntOpenHashMap<>();
+
+    @Override
+    public String id() {
+        return "entity_sleep_monitor";
+    }
+
+    @Override
+    public boolean isEnabled(AdaptiveSystemsConfig.AdaptiveSystemsValues config) {
+        return config.enableEntitySleepMonitor();
+    }
+
+    @Override
+    public void tick(MinecraftServer server, SafetyContext context) {
+        if (!context.allowWork()) {
+            return;
+        }
+        if (context.tickCounter() % context.config().sampleIntervalTicks() != 0) {
+            return;
+        }
+
+        for (ServerLevel level : server.getAllLevels()) {
+            ResourceKey<Level> dimension = level.dimension();
+            Int2LongOpenHashMap lastActive = lastActiveTick.computeIfAbsent(dimension, key -> new Int2LongOpenHashMap());
+            long now = level.getGameTime();
+            for (ServerPlayer player : level.players()) {
+                if (!context.sampleBudget().tryConsume(1)) {
+                    return;
+                }
+                for (Mob mob : level.getEntitiesOfClass(Mob.class, player.getBoundingBox().inflate(SAMPLE_RADIUS))) {
+                    if (mob.getDeltaMovement().lengthSqr() >= ACTIVE_MOVEMENT_THRESHOLD) {
+                        lastActive.put(mob.getId(), now);
+                    }
+                }
+            }
+
+            int idle = 0;
+            Iterator<Map.Entry<Integer, Long>> iterator = lastActive.int2LongEntrySet().iterator();
+            while (iterator.hasNext()) {
+                Map.Entry<Integer, Long> entry = iterator.next();
+                if (now - entry.getValue() > context.config().entityIdleTicks()) {
+                    idle++;
+                }
+                if (lastActive.size() > context.config().maxTrackedChunks()) {
+                    iterator.remove();
+                }
+            }
+            idleCounts.put(dimension, idle);
+        }
+    }
+}

--- a/src/main/java/com/thunder/novaapi/systems/InventoryHeatSystem.java
+++ b/src/main/java/com/thunder/novaapi/systems/InventoryHeatSystem.java
@@ -2,7 +2,9 @@ package com.thunder.novaapi.systems;
 
 import com.thunder.novaapi.config.AdaptiveSystemsConfig;
 import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
+import it.unimi.dsi.fastutil.longs.Long2LongMap;
 import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectIterator;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.resources.ResourceKey;
@@ -13,9 +15,6 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
-
-import java.util.Iterator;
-import java.util.Map;
 
 public class InventoryHeatSystem implements AdaptiveSystem {
     private final Object2ObjectOpenHashMap<ResourceKey<Level>, Long2IntOpenHashMap> accessCounts = new Object2ObjectOpenHashMap<>();
@@ -75,11 +74,11 @@ public class InventoryHeatSystem implements AdaptiveSystem {
         }
         Long2IntOpenHashMap counts = accessCounts.get(dimension);
         long ttl = config.chunkActivityTtlTicks();
-        Iterator<Map.Entry<Long, Long>> iterator = last.long2LongEntrySet().iterator();
+        ObjectIterator<Long2LongMap.Entry> iterator = last.long2LongEntrySet().iterator();
         while (iterator.hasNext()) {
-            Map.Entry<Long, Long> entry = iterator.next();
-            if (gameTime - entry.getValue() > ttl) {
-                long key = entry.getKey();
+            Long2LongMap.Entry entry = iterator.next();
+            if (gameTime - entry.getLongValue() > ttl) {
+                long key = entry.getLongKey();
                 iterator.remove();
                 if (counts != null) {
                     counts.remove(key);
@@ -92,8 +91,8 @@ public class InventoryHeatSystem implements AdaptiveSystem {
         int toRemove = last.size() - config.maxTrackedChunks();
         iterator = last.long2LongEntrySet().iterator();
         while (iterator.hasNext() && toRemove > 0) {
-            Map.Entry<Long, Long> entry = iterator.next();
-            long key = entry.getKey();
+            Long2LongMap.Entry entry = iterator.next();
+            long key = entry.getLongKey();
             iterator.remove();
             if (counts != null) {
                 counts.remove(key);

--- a/src/main/java/com/thunder/novaapi/systems/InventoryHeatSystem.java
+++ b/src/main/java/com/thunder/novaapi/systems/InventoryHeatSystem.java
@@ -1,0 +1,104 @@
+package com.thunder.novaapi.systems;
+
+import com.thunder.novaapi.config.AdaptiveSystemsConfig;
+import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
+import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import net.minecraft.core.BlockPos;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.Container;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
+
+import java.util.Iterator;
+import java.util.Map;
+
+public class InventoryHeatSystem implements AdaptiveSystem {
+    private final Object2ObjectOpenHashMap<ResourceKey<Level>, Long2IntOpenHashMap> accessCounts = new Object2ObjectOpenHashMap<>();
+    private final Object2ObjectOpenHashMap<ResourceKey<Level>, Long2LongOpenHashMap> lastAccess = new Object2ObjectOpenHashMap<>();
+
+    @Override
+    public String id() {
+        return "inventory_heat";
+    }
+
+    @Override
+    public boolean isEnabled(AdaptiveSystemsConfig.AdaptiveSystemsValues config) {
+        return config.enableInventoryHeatTracking();
+    }
+
+    @Override
+    public void tick(MinecraftServer server, SafetyContext context) {
+        if (!context.allowWork()) {
+            return;
+        }
+        if (context.tickCounter() % context.config().sampleIntervalTicks() != 0) {
+            return;
+        }
+        if (!context.sampleBudget().tryConsume(1)) {
+            return;
+        }
+
+        for (ServerLevel level : server.getAllLevels()) {
+            prune(level.dimension(), context.config(), level.getGameTime());
+        }
+    }
+
+    @SubscribeEvent
+    public void onContainerInteract(PlayerInteractEvent.RightClickBlock event) {
+        if (!(event.getLevel() instanceof ServerLevel level)) {
+            return;
+        }
+        BlockPos pos = event.getPos();
+        BlockEntity blockEntity = level.getBlockEntity(pos);
+        if (!(blockEntity instanceof Container)) {
+            return;
+        }
+        ResourceKey<Level> dimension = level.dimension();
+        Long2IntOpenHashMap counts = accessCounts.computeIfAbsent(dimension, key -> new Long2IntOpenHashMap());
+        Long2LongOpenHashMap last = lastAccess.computeIfAbsent(dimension, key -> new Long2LongOpenHashMap());
+        long key = pos.asLong();
+        counts.addTo(key, 1);
+        last.put(key, level.getGameTime());
+    }
+
+    private void prune(ResourceKey<Level> dimension,
+                       AdaptiveSystemsConfig.AdaptiveSystemsValues config,
+                       long gameTime) {
+        Long2LongOpenHashMap last = lastAccess.get(dimension);
+        if (last == null) {
+            return;
+        }
+        Long2IntOpenHashMap counts = accessCounts.get(dimension);
+        long ttl = config.chunkActivityTtlTicks();
+        Iterator<Map.Entry<Long, Long>> iterator = last.long2LongEntrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<Long, Long> entry = iterator.next();
+            if (gameTime - entry.getValue() > ttl) {
+                long key = entry.getKey();
+                iterator.remove();
+                if (counts != null) {
+                    counts.remove(key);
+                }
+            }
+        }
+        if (last.size() <= config.maxTrackedChunks()) {
+            return;
+        }
+        int toRemove = last.size() - config.maxTrackedChunks();
+        iterator = last.long2LongEntrySet().iterator();
+        while (iterator.hasNext() && toRemove > 0) {
+            Map.Entry<Long, Long> entry = iterator.next();
+            long key = entry.getKey();
+            iterator.remove();
+            if (counts != null) {
+                counts.remove(key);
+            }
+            toRemove--;
+        }
+    }
+}

--- a/src/main/java/com/thunder/novaapi/systems/LogisticsNetworkMonitorSystem.java
+++ b/src/main/java/com/thunder/novaapi/systems/LogisticsNetworkMonitorSystem.java
@@ -1,0 +1,48 @@
+package com.thunder.novaapi.systems;
+
+import com.thunder.novaapi.config.AdaptiveSystemsConfig;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.item.ItemEntity;
+import net.minecraft.world.level.Level;
+
+public class LogisticsNetworkMonitorSystem implements AdaptiveSystem {
+    private static final double SAMPLE_RADIUS = 32.0D;
+    private final Object2IntOpenHashMap<ResourceKey<Level>> itemPressure = new Object2IntOpenHashMap<>();
+
+    @Override
+    public String id() {
+        return "logistics_network_monitor";
+    }
+
+    @Override
+    public boolean isEnabled(AdaptiveSystemsConfig.AdaptiveSystemsValues config) {
+        return config.enableLogisticsNetworkMonitor();
+    }
+
+    @Override
+    public void tick(MinecraftServer server, SafetyContext context) {
+        if (!context.allowWork()) {
+            return;
+        }
+        if (context.tickCounter() % context.config().sampleIntervalTicks() != 0) {
+            return;
+        }
+
+        itemPressure.clear();
+        for (ServerLevel level : server.getAllLevels()) {
+            ResourceKey<Level> dimension = level.dimension();
+            int pressure = 0;
+            for (ServerPlayer player : level.players()) {
+                if (!context.sampleBudget().tryConsume(1)) {
+                    return;
+                }
+                pressure += level.getEntitiesOfClass(ItemEntity.class, player.getBoundingBox().inflate(SAMPLE_RADIUS)).size();
+            }
+            itemPressure.put(dimension, pressure);
+        }
+    }
+}

--- a/src/main/java/com/thunder/novaapi/systems/MobEcologyBalancerSystem.java
+++ b/src/main/java/com/thunder/novaapi/systems/MobEcologyBalancerSystem.java
@@ -1,0 +1,57 @@
+package com.thunder.novaapi.systems;
+
+import com.thunder.novaapi.config.AdaptiveSystemsConfig;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import net.minecraft.core.Holder;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.level.biome.Biome;
+
+import java.util.Optional;
+
+public class MobEcologyBalancerSystem implements AdaptiveSystem {
+    private static final double SAMPLE_RADIUS = 48.0D;
+    private final Object2IntOpenHashMap<ResourceKey<Biome>> biomePressure = new Object2IntOpenHashMap<>();
+
+    @Override
+    public String id() {
+        return "mob_ecology";
+    }
+
+    @Override
+    public boolean isEnabled(AdaptiveSystemsConfig.AdaptiveSystemsValues config) {
+        return config.enableMobEcology();
+    }
+
+    @Override
+    public void tick(MinecraftServer server, SafetyContext context) {
+        if (!context.allowWork()) {
+            return;
+        }
+        if (context.tickCounter() % context.config().sampleIntervalTicks() != 0) {
+            return;
+        }
+
+        biomePressure.clear();
+        int samples = 0;
+        for (ServerLevel level : server.getAllLevels()) {
+            for (ServerPlayer player : level.players()) {
+                if (!context.sampleBudget().tryConsume(1)) {
+                    return;
+                }
+                int mobCount = level.getEntitiesOfClass(Mob.class, player.getBoundingBox().inflate(SAMPLE_RADIUS)).size();
+                Holder<Biome> biomeHolder = level.getBiome(player.blockPosition());
+                Optional<ResourceKey<Biome>> biomeKey = biomeHolder.unwrapKey();
+                biomeKey.ifPresent(key -> biomePressure.addTo(key, mobCount));
+                samples++;
+            }
+        }
+
+        if (samples == 0) {
+            return;
+        }
+    }
+}

--- a/src/main/java/com/thunder/novaapi/systems/RedstoneLoadMonitorSystem.java
+++ b/src/main/java/com/thunder/novaapi/systems/RedstoneLoadMonitorSystem.java
@@ -1,0 +1,44 @@
+package com.thunder.novaapi.systems;
+
+import com.thunder.novaapi.config.AdaptiveSystemsConfig;
+import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.Level;
+
+public class RedstoneLoadMonitorSystem implements AdaptiveSystem {
+    private final Object2LongOpenHashMap<ResourceKey<Level>> scheduledTickLoad = new Object2LongOpenHashMap<>();
+
+    @Override
+    public String id() {
+        return "redstone_load_monitor";
+    }
+
+    @Override
+    public boolean isEnabled(AdaptiveSystemsConfig.AdaptiveSystemsValues config) {
+        return config.enableRedstoneLoadMonitor();
+    }
+
+    @Override
+    public void tick(MinecraftServer server, SafetyContext context) {
+        if (!context.allowWork()) {
+            return;
+        }
+        if (context.tickCounter() % context.config().sampleIntervalTicks() != 0) {
+            return;
+        }
+
+        int levels = server.getAllLevels().size();
+        if (!context.sampleBudget().tryConsume(Math.max(1, levels))) {
+            return;
+        }
+
+        for (ServerLevel level : server.getAllLevels()) {
+            ResourceKey<Level> dimension = level.dimension();
+            long blockTicks = level.getBlockTicks().count();
+            long fluidTicks = level.getFluidTicks().count();
+            scheduledTickLoad.put(dimension, blockTicks + fluidTicks);
+        }
+    }
+}

--- a/src/main/java/com/thunder/novaapi/systems/RedstoneLoadMonitorSystem.java
+++ b/src/main/java/com/thunder/novaapi/systems/RedstoneLoadMonitorSystem.java
@@ -29,12 +29,10 @@ public class RedstoneLoadMonitorSystem implements AdaptiveSystem {
             return;
         }
 
-        int levels = server.getAllLevels().size();
-        if (!context.sampleBudget().tryConsume(Math.max(1, levels))) {
-            return;
-        }
-
         for (ServerLevel level : server.getAllLevels()) {
+            if (!context.sampleBudget().tryConsume(1)) {
+                return;
+            }
             ResourceKey<Level> dimension = level.dimension();
             long blockTicks = level.getBlockTicks().count();
             long fluidTicks = level.getFluidTicks().count();

--- a/src/main/java/com/thunder/novaapi/systems/RegionIntelligenceSystem.java
+++ b/src/main/java/com/thunder/novaapi/systems/RegionIntelligenceSystem.java
@@ -2,7 +2,9 @@ package com.thunder.novaapi.systems;
 
 import com.thunder.novaapi.config.AdaptiveSystemsConfig;
 import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
+import it.unimi.dsi.fastutil.longs.Long2LongMap;
 import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectIterator;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
@@ -10,9 +12,6 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
-
-import java.util.Iterator;
-import java.util.Map;
 
 public class RegionIntelligenceSystem implements AdaptiveSystem {
     private final Object2ObjectOpenHashMap<ResourceKey<Level>, Long2LongOpenHashMap> lastSeen = new Object2ObjectOpenHashMap<>();
@@ -61,11 +60,11 @@ public class RegionIntelligenceSystem implements AdaptiveSystem {
                        long tickCounter) {
         long ttl = config.chunkActivityTtlTicks();
         if (ttl > 0) {
-            Iterator<Map.Entry<Long, Long>> iterator = lastSeenMap.long2LongEntrySet().iterator();
+            ObjectIterator<Long2LongMap.Entry> iterator = lastSeenMap.long2LongEntrySet().iterator();
             while (iterator.hasNext()) {
-                Map.Entry<Long, Long> entry = iterator.next();
-                if (tickCounter - entry.getValue() > ttl) {
-                    long key = entry.getKey();
+                Long2LongMap.Entry entry = iterator.next();
+                if (tickCounter - entry.getLongValue() > ttl) {
+                    long key = entry.getLongKey();
                     iterator.remove();
                     scoreMap.remove(key);
                 }
@@ -78,10 +77,10 @@ public class RegionIntelligenceSystem implements AdaptiveSystem {
         }
 
         int toRemove = Math.max(0, lastSeenMap.size() - maxTracked);
-        Iterator<Map.Entry<Long, Long>> iterator = lastSeenMap.long2LongEntrySet().iterator();
+        ObjectIterator<Long2LongMap.Entry> iterator = lastSeenMap.long2LongEntrySet().iterator();
         while (iterator.hasNext() && toRemove > 0) {
-            Map.Entry<Long, Long> entry = iterator.next();
-            long key = entry.getKey();
+            Long2LongMap.Entry entry = iterator.next();
+            long key = entry.getLongKey();
             iterator.remove();
             scoreMap.remove(key);
             toRemove--;

--- a/src/main/java/com/thunder/novaapi/systems/RegionIntelligenceSystem.java
+++ b/src/main/java/com/thunder/novaapi/systems/RegionIntelligenceSystem.java
@@ -1,0 +1,90 @@
+package com.thunder.novaapi.systems;
+
+import com.thunder.novaapi.config.AdaptiveSystemsConfig;
+import it.unimi.dsi.fastutil.longs.Long2IntOpenHashMap;
+import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
+
+import java.util.Iterator;
+import java.util.Map;
+
+public class RegionIntelligenceSystem implements AdaptiveSystem {
+    private final Object2ObjectOpenHashMap<ResourceKey<Level>, Long2LongOpenHashMap> lastSeen = new Object2ObjectOpenHashMap<>();
+    private final Object2ObjectOpenHashMap<ResourceKey<Level>, Long2IntOpenHashMap> activityScore = new Object2ObjectOpenHashMap<>();
+
+    @Override
+    public String id() {
+        return "region_intelligence";
+    }
+
+    @Override
+    public boolean isEnabled(AdaptiveSystemsConfig.AdaptiveSystemsValues config) {
+        return config.enableRegionIntelligence();
+    }
+
+    @Override
+    public void tick(MinecraftServer server, SafetyContext context) {
+        if (!context.allowWork()) {
+            return;
+        }
+        if (context.tickCounter() % context.config().sampleIntervalTicks() != 0) {
+            return;
+        }
+        int playerCount = server.getPlayerList().getPlayerCount();
+        if (!context.sampleBudget().tryConsume(Math.max(1, playerCount))) {
+            return;
+        }
+
+        for (ServerLevel level : server.getAllLevels()) {
+            ResourceKey<Level> dimension = level.dimension();
+            Long2LongOpenHashMap dimensionLastSeen = lastSeen.computeIfAbsent(dimension, key -> new Long2LongOpenHashMap());
+            Long2IntOpenHashMap dimensionScore = activityScore.computeIfAbsent(dimension, key -> new Long2IntOpenHashMap());
+            for (ServerPlayer player : level.players()) {
+                ChunkPos chunkPos = player.chunkPosition();
+                long chunkKey = chunkPos.toLong();
+                dimensionLastSeen.put(chunkKey, context.tickCounter());
+                dimensionScore.addTo(chunkKey, 1);
+            }
+            prune(dimensionLastSeen, dimensionScore, context.config(), context.tickCounter());
+        }
+    }
+
+    private void prune(Long2LongOpenHashMap lastSeenMap,
+                       Long2IntOpenHashMap scoreMap,
+                       AdaptiveSystemsConfig.AdaptiveSystemsValues config,
+                       long tickCounter) {
+        long ttl = config.chunkActivityTtlTicks();
+        if (ttl > 0) {
+            Iterator<Map.Entry<Long, Long>> iterator = lastSeenMap.long2LongEntrySet().iterator();
+            while (iterator.hasNext()) {
+                Map.Entry<Long, Long> entry = iterator.next();
+                if (tickCounter - entry.getValue() > ttl) {
+                    long key = entry.getKey();
+                    iterator.remove();
+                    scoreMap.remove(key);
+                }
+            }
+        }
+
+        int maxTracked = config.maxTrackedChunks();
+        if (lastSeenMap.size() <= maxTracked) {
+            return;
+        }
+
+        int toRemove = Math.max(0, lastSeenMap.size() - maxTracked);
+        Iterator<Map.Entry<Long, Long>> iterator = lastSeenMap.long2LongEntrySet().iterator();
+        while (iterator.hasNext() && toRemove > 0) {
+            Map.Entry<Long, Long> entry = iterator.next();
+            long key = entry.getKey();
+            iterator.remove();
+            scoreMap.remove(key);
+            toRemove--;
+        }
+    }
+}

--- a/src/main/java/com/thunder/novaapi/systems/SafetyContext.java
+++ b/src/main/java/com/thunder/novaapi/systems/SafetyContext.java
@@ -1,0 +1,20 @@
+package com.thunder.novaapi.systems;
+
+import com.thunder.novaapi.config.AdaptiveSystemsConfig;
+
+public record SafetyContext(
+        AdaptiveSystemsConfig.AdaptiveSystemsValues config,
+        SampleBudget sampleBudget,
+        long tickCounter,
+        long tickTimeMs,
+        long usedMemoryMb,
+        long maxMemoryMb,
+        long freeMemoryMb,
+        boolean overTickBudget,
+        boolean memoryPressure,
+        boolean cooldownActive
+) {
+    public boolean allowWork() {
+        return !overTickBudget && !memoryPressure && !cooldownActive;
+    }
+}

--- a/src/main/java/com/thunder/novaapi/systems/SafetyMonitor.java
+++ b/src/main/java/com/thunder/novaapi/systems/SafetyMonitor.java
@@ -1,0 +1,35 @@
+package com.thunder.novaapi.systems;
+
+import com.thunder.novaapi.MemUtils.MemoryUtils;
+import com.thunder.novaapi.config.AdaptiveSystemsConfig;
+
+public class SafetyMonitor {
+    private long lastTickNanos = 0L;
+    private long lastTickDurationMs = 0L;
+
+    public SafetySnapshot sample(AdaptiveSystemsConfig.AdaptiveSystemsValues config) {
+        long now = System.nanoTime();
+        if (lastTickNanos != 0L) {
+            lastTickDurationMs = (now - lastTickNanos) / 1_000_000L;
+        }
+        lastTickNanos = now;
+
+        long usedMb = MemoryUtils.getUsedMemoryMB();
+        long maxMb = Runtime.getRuntime().maxMemory() / (1024L * 1024L);
+        long freeMb = Math.max(0L, maxMb - usedMb);
+        boolean overTickBudget = lastTickDurationMs > config.safetyTickBudgetMs();
+        boolean memoryPressure = freeMb < config.safetyMinFreeMemoryMb();
+
+        return new SafetySnapshot(lastTickDurationMs, usedMb, maxMb, freeMb, overTickBudget, memoryPressure);
+    }
+
+    public record SafetySnapshot(
+            long tickTimeMs,
+            long usedMemoryMb,
+            long maxMemoryMb,
+            long freeMemoryMb,
+            boolean overTickBudget,
+            boolean memoryPressure
+    ) {
+    }
+}

--- a/src/main/java/com/thunder/novaapi/systems/SampleBudget.java
+++ b/src/main/java/com/thunder/novaapi/systems/SampleBudget.java
@@ -1,0 +1,22 @@
+package com.thunder.novaapi.systems;
+
+public final class SampleBudget {
+    private int remaining;
+
+    public SampleBudget(int maxSamples) {
+        this.remaining = Math.max(0, maxSamples);
+    }
+
+    public boolean tryConsume(int amount) {
+        int cost = Math.max(0, amount);
+        if (remaining < cost) {
+            return false;
+        }
+        remaining -= cost;
+        return true;
+    }
+
+    public int remaining() {
+        return remaining;
+    }
+}

--- a/src/main/java/com/thunder/novaapi/systems/SimulationDensitySystem.java
+++ b/src/main/java/com/thunder/novaapi/systems/SimulationDensitySystem.java
@@ -1,0 +1,58 @@
+package com.thunder.novaapi.systems;
+
+import com.thunder.novaapi.config.AdaptiveSystemsConfig;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.Level;
+
+public class SimulationDensitySystem implements AdaptiveSystem {
+    private static final double NEAR_RADIUS = 64.0D;
+    private static final double MID_RADIUS = 128.0D;
+    private static final double FAR_RADIUS = 192.0D;
+
+    private final Object2ObjectOpenHashMap<ResourceKey<Level>, DensitySnapshot> densitySnapshot = new Object2ObjectOpenHashMap<>();
+
+    @Override
+    public String id() {
+        return "simulation_density_scaler";
+    }
+
+    @Override
+    public boolean isEnabled(AdaptiveSystemsConfig.AdaptiveSystemsValues config) {
+        return config.enableSimulationDensityScaler();
+    }
+
+    @Override
+    public void tick(MinecraftServer server, SafetyContext context) {
+        if (!context.allowWork()) {
+            return;
+        }
+        if (context.tickCounter() % context.config().sampleIntervalTicks() != 0) {
+            return;
+        }
+        if (!context.sampleBudget().tryConsume(1)) {
+            return;
+        }
+
+        for (ServerLevel level : server.getAllLevels()) {
+            int maxNear = 0;
+            int maxMid = 0;
+            int maxFar = 0;
+            for (ServerPlayer player : level.players()) {
+                if (!context.sampleBudget().tryConsume(1)) {
+                    return;
+                }
+                maxNear = Math.max(maxNear, level.getEntitiesOfClass(ServerPlayer.class, player.getBoundingBox().inflate(NEAR_RADIUS)).size());
+                maxMid = Math.max(maxMid, level.getEntitiesOfClass(ServerPlayer.class, player.getBoundingBox().inflate(MID_RADIUS)).size());
+                maxFar = Math.max(maxFar, level.getEntitiesOfClass(ServerPlayer.class, player.getBoundingBox().inflate(FAR_RADIUS)).size());
+            }
+            densitySnapshot.put(level.dimension(), new DensitySnapshot(maxNear, maxMid, maxFar));
+        }
+    }
+
+    private record DensitySnapshot(int nearPlayers, int midPlayers, int farPlayers) {
+    }
+}

--- a/src/main/java/com/thunder/novaapi/systems/StructureIndexSystem.java
+++ b/src/main/java/com/thunder/novaapi/systems/StructureIndexSystem.java
@@ -1,7 +1,9 @@
 package com.thunder.novaapi.systems;
 
 import com.thunder.novaapi.config.AdaptiveSystemsConfig;
+import it.unimi.dsi.fastutil.longs.Long2LongMap;
 import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectIterator;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
@@ -10,9 +12,6 @@ import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.neoforge.event.level.ChunkEvent;
-
-import java.util.Iterator;
-import java.util.Map;
 
 public class StructureIndexSystem implements AdaptiveSystem {
     private final Object2ObjectOpenHashMap<ResourceKey<Level>, Long2LongOpenHashMap> loadedChunks = new Object2ObjectOpenHashMap<>();
@@ -78,10 +77,10 @@ public class StructureIndexSystem implements AdaptiveSystem {
                        AdaptiveSystemsConfig.AdaptiveSystemsValues config,
                        long gameTime) {
         long ttl = config.chunkActivityTtlTicks();
-        Iterator<Map.Entry<Long, Long>> iterator = chunkMap.long2LongEntrySet().iterator();
+        ObjectIterator<Long2LongMap.Entry> iterator = chunkMap.long2LongEntrySet().iterator();
         while (iterator.hasNext()) {
-            Map.Entry<Long, Long> entry = iterator.next();
-            if (gameTime - entry.getValue() > ttl) {
+            Long2LongMap.Entry entry = iterator.next();
+            if (gameTime - entry.getLongValue() > ttl) {
                 iterator.remove();
             }
         }

--- a/src/main/java/com/thunder/novaapi/systems/StructureIndexSystem.java
+++ b/src/main/java/com/thunder/novaapi/systems/StructureIndexSystem.java
@@ -1,0 +1,101 @@
+package com.thunder.novaapi.systems;
+
+import com.thunder.novaapi.config.AdaptiveSystemsConfig;
+import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.neoforge.event.level.ChunkEvent;
+
+import java.util.Iterator;
+import java.util.Map;
+
+public class StructureIndexSystem implements AdaptiveSystem {
+    private final Object2ObjectOpenHashMap<ResourceKey<Level>, Long2LongOpenHashMap> loadedChunks = new Object2ObjectOpenHashMap<>();
+
+    @Override
+    public String id() {
+        return "structure_index";
+    }
+
+    @Override
+    public boolean isEnabled(AdaptiveSystemsConfig.AdaptiveSystemsValues config) {
+        return config.enableStructureIndex();
+    }
+
+    @Override
+    public void tick(MinecraftServer server, SafetyContext context) {
+        if (!context.allowWork()) {
+            return;
+        }
+        if (context.tickCounter() % context.config().sampleIntervalTicks() != 0) {
+            return;
+        }
+        if (!context.sampleBudget().tryConsume(1)) {
+            return;
+        }
+
+        for (ServerLevel level : server.getAllLevels()) {
+            ResourceKey<Level> dimension = level.dimension();
+            Long2LongOpenHashMap chunkMap = loadedChunks.get(dimension);
+            if (chunkMap == null) {
+                continue;
+            }
+            prune(chunkMap, context.config(), level.getGameTime());
+        }
+    }
+
+    @SubscribeEvent
+    public void onChunkLoad(ChunkEvent.Load event) {
+        if (!(event.getLevel() instanceof ServerLevel level)) {
+            return;
+        }
+        ResourceKey<Level> dimension = level.dimension();
+        Long2LongOpenHashMap chunkMap = loadedChunks.computeIfAbsent(dimension, key -> new Long2LongOpenHashMap());
+        ChunkPos chunkPos = event.getChunk().getPos();
+        chunkMap.put(chunkPos.toLong(), level.getGameTime());
+    }
+
+    @SubscribeEvent
+    public void onChunkUnload(ChunkEvent.Unload event) {
+        if (!(event.getLevel() instanceof ServerLevel level)) {
+            return;
+        }
+        ResourceKey<Level> dimension = level.dimension();
+        Long2LongOpenHashMap chunkMap = loadedChunks.get(dimension);
+        if (chunkMap == null) {
+            return;
+        }
+        ChunkPos chunkPos = event.getChunk().getPos();
+        chunkMap.remove(chunkPos.toLong());
+    }
+
+    private void prune(Long2LongOpenHashMap chunkMap,
+                       AdaptiveSystemsConfig.AdaptiveSystemsValues config,
+                       long gameTime) {
+        long ttl = config.chunkActivityTtlTicks();
+        Iterator<Map.Entry<Long, Long>> iterator = chunkMap.long2LongEntrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<Long, Long> entry = iterator.next();
+            if (gameTime - entry.getValue() > ttl) {
+                iterator.remove();
+            }
+        }
+
+        int maxTracked = config.maxTrackedChunks();
+        if (chunkMap.size() <= maxTracked) {
+            return;
+        }
+        int toRemove = chunkMap.size() - maxTracked;
+        iterator = chunkMap.long2LongEntrySet().iterator();
+        while (iterator.hasNext() && toRemove > 0) {
+            iterator.next();
+            iterator.remove();
+            toRemove--;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce a feature-scale adaptive systems layer to gather simulation telemetry and make runtime tuning decisions while avoiding added server load. 
- Provide configurable safety guardrails (tick budget, memory thresholds, cooldowns, sampling budgets) so the new systems back off automatically under pressure. 
- Offer a modular platform for future optimization systems (region heatmaps, ecology signals, redstone/item pressure, etc.) without coupling them directly into core subsystems.

### Description
- Add a new configuration surface via `AdaptiveSystemsConfig` with toggles, sampling limits and safety parameters and register it in `NovaAPI` using `ConfigRegistrationValidator`. 
- Implement an `AdaptiveSystemsManager` that samples a `SafetyMonitor`, enforces a `SampleBudget`, creates a `SafetyContext`, and ticks registered `AdaptiveSystem` implementations. 
- Add safety/support primitives: `SafetyMonitor`, `SafetyContext`, and `SampleBudget` and wire the manager into `NovaAPI` lifecycle and `ServerTickEvent` with `adaptiveSystemsManager.tick(server)`. 
- Add initial adaptive systems: `RegionIntelligenceSystem`, `MobEcologyBalancerSystem`, `RedstoneLoadMonitorSystem`, `LogisticsNetworkMonitorSystem`, `ChunkAwareAiSchedulerSystem`, `StructureIndexSystem`, `DynamicWeatherSchedulerSystem`, `SimulationDensitySystem`, `InventoryHeatSystem`, and `EntitySleepMonitorSystem`, and register event listeners via `NeoForge.EVENT_BUS.register(...)`. 
- Document the new layer in `docs/adaptive-systems.md` and add a reference from `README.md`.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69719abf699c8328bf0e044a4f841da7)