### PR TITLE
Gate memory and thread debug logging behind config

### DIFF
--- a/src/main/java/com/thunder/novaapi/MemUtils/MemoryUtils.java
+++ b/src/main/java/com/thunder/novaapi/MemUtils/MemoryUtils.java
@@ -2,6 +2,7 @@ package com.thunder.novaapi.MemUtils;
 
 
 import com.thunder.novaapi.Core.NovaAPI;
+import com.thunder.novaapi.config.NovaAPIConfig;
 
 /**
  * Utility methods for inspecting runtime memory usage and recommending RAM
@@ -28,7 +29,7 @@ public class MemoryUtils {
         long used = getUsedMemoryMB();
         if (used > peakUsedMB) {
             peakUsedMB = used;
-            if (NovaAPI.LOGGER.isDebugEnabled()) {
+            if (NovaAPIConfig.isMemoryThreadLogsEnabled() && NovaAPI.LOGGER.isDebugEnabled()) {
                 NovaAPI.LOGGER.debug("New peak memory usage recorded: {} MB", peakUsedMB);
             }
         }
@@ -57,11 +58,13 @@ public class MemoryUtils {
         if (used != lastLoggedUsedMB && (now - lastUsedLogTimestampMs) >= USED_LOG_INTERVAL_MS) {
             lastLoggedUsedMB = used;
             lastUsedLogTimestampMs = now;
-            NovaAPI.LOGGER.debug(
-                    "Calculated used memory: {} MB (total={} MB, free={} MB)",
-                    used,
-                    total / MB,
-                    free / MB);
+            if (NovaAPIConfig.isMemoryThreadLogsEnabled()) {
+                NovaAPI.LOGGER.debug(
+                        "Calculated used memory: {} MB (total={} MB, free={} MB)",
+                        used,
+                        total / MB,
+                        free / MB);
+            }
         }
         return used;
     }
@@ -76,7 +79,9 @@ public class MemoryUtils {
         long totalMB = total / MB;
         if (totalMB != lastLoggedTotalMB) {
             lastLoggedTotalMB = totalMB;
-            NovaAPI.LOGGER.debug("Total memory allocated: {} MB", totalMB);
+            if (NovaAPIConfig.isMemoryThreadLogsEnabled()) {
+                NovaAPI.LOGGER.debug("Total memory allocated: {} MB", totalMB);
+            }
         }
         return totalMB;
     }
@@ -90,7 +95,7 @@ public class MemoryUtils {
      */
     private static int lastRecommendedMB = -1;
     public static int calculateRecommendedRAM(long currentUsedMB, int modCount) {
-        if (NovaAPI.LOGGER.isDebugEnabled()) {
+        if (NovaAPIConfig.isMemoryThreadLogsEnabled() && NovaAPI.LOGGER.isDebugEnabled()) {
             NovaAPI.LOGGER.debug("Calculating recommended RAM with currentUsedMB={} and modCount={}", currentUsedMB, modCount);
         }
         int extraPer10Mods = (modCount / 10) * 128;
@@ -101,7 +106,7 @@ public class MemoryUtils {
         }
         if (recommendedMB != lastRecommendedMB) {
             lastRecommendedMB = recommendedMB;
-            if (NovaAPI.LOGGER.isDebugEnabled()) {
+            if (NovaAPIConfig.isMemoryThreadLogsEnabled() && NovaAPI.LOGGER.isDebugEnabled()) {
                 NovaAPI.LOGGER.debug("Recommended RAM determined to be {} MB", recommendedMB);
             }
         }

--- a/src/main/java/com/thunder/novaapi/config/NovaAPIConfig.java
+++ b/src/main/java/com/thunder/novaapi/config/NovaAPIConfig.java
@@ -9,6 +9,7 @@ public class NovaAPIConfig {
     // 🔹 General Settings
     public static final ModConfigSpec.BooleanValue ENABLE_NOVA_API;
     public static final ModConfigSpec.BooleanValue MODPACK_RESOURCE_PROFILE;
+    public static final ModConfigSpec.BooleanValue ENABLE_MEMORY_THREAD_LOGS;
 
     // 🔹 Chunk Optimization Settings
     public static final ModConfigSpec.BooleanValue ENABLE_CHUNK_OPTIMIZATIONS;
@@ -26,6 +27,9 @@ public class NovaAPIConfig {
         MODPACK_RESOURCE_PROFILE = BUILDER
                 .comment("Enable modpack-friendly tuning to lower CPU and memory usage (auto-adjusts Nova API internal limits).")
                 .define("modpackResourceProfile", false);
+        ENABLE_MEMORY_THREAD_LOGS = BUILDER
+                .comment("Enable debug logs for memory usage and thread counts.")
+                .define("enableMemoryThreadLogs", false);
         BUILDER.pop();
 
         BUILDER.push("Chunk Optimization Settings");
@@ -54,6 +58,14 @@ public class NovaAPIConfig {
             return MODPACK_RESOURCE_PROFILE.get();
         } catch (IllegalStateException ex) {
             return MODPACK_RESOURCE_PROFILE.getDefault();
+        }
+    }
+
+    public static boolean isMemoryThreadLogsEnabled() {
+        try {
+            return ENABLE_MEMORY_THREAD_LOGS.get();
+        } catch (IllegalStateException ex) {
+            return ENABLE_MEMORY_THREAD_LOGS.getDefault();
         }
     }
 }

--- a/src/main/java/com/thunder/novaapi/utils/ThreadMonitor.java
+++ b/src/main/java/com/thunder/novaapi/utils/ThreadMonitor.java
@@ -1,6 +1,7 @@
 package com.thunder.novaapi.utils;
 
 import com.thunder.novaapi.Core.NovaAPI;
+import com.thunder.novaapi.config.NovaAPIConfig;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
@@ -47,6 +48,9 @@ public class ThreadMonitor {
     }
 
     private static void logAllThreads() {
+        if (!NovaAPIConfig.isMemoryThreadLogsEnabled()) {
+            return;
+        }
         Map<Thread, StackTraceElement[]> threads = Thread.getAllStackTraces();
         NovaAPI.LOGGER.debug("📌 Active Threads: {}", threads.size());
 
@@ -68,7 +72,9 @@ public class ThreadMonitor {
                         info.getThreadName(), info.getThreadState(), info.getLockOwnerName());
             }
         } else {
-            NovaAPI.LOGGER.debug("✅ No deadlocked threads detected.");
+            if (NovaAPIConfig.isMemoryThreadLogsEnabled()) {
+                NovaAPI.LOGGER.debug("✅ No deadlocked threads detected.");
+            }
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Reduce noisy/verbose debug output (e.g. peak memory and thread listings) by making memory and thread debug logs opt-in via a config flag, defaulting to false.

### Description
- Add a new config option `ENABLE_MEMORY_THREAD_LOGS` (accessed via `isMemoryThreadLogsEnabled()`) and guard memory logging in `MemoryUtils` and thread listing/logs in `ThreadMonitor` so those debug messages only emit when the flag is enabled.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971af8d1ff88328ae88d9cdca694c2c)