### PR TITLE
Guard event bus registration for adaptive systems

### DIFF
--- a/src/main/java/com/thunder/novaapi/systems/AdaptiveSystemsManager.java
+++ b/src/main/java/com/thunder/novaapi/systems/AdaptiveSystemsManager.java
@@ -2,8 +2,10 @@ package com.thunder.novaapi.systems;
 
 import com.thunder.novaapi.config.AdaptiveSystemsConfig;
 import net.minecraft.server.MinecraftServer;
+import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.neoforge.common.NeoForge;
 
+import java.lang.reflect.Method;
 import java.util.List;
 
 public class AdaptiveSystemsManager {
@@ -78,8 +80,19 @@ public class AdaptiveSystemsManager {
             return;
         }
         for (AdaptiveSystem system : systems) {
-            NeoForge.EVENT_BUS.register(system);
+            if (hasEventHandlers(system)) {
+                NeoForge.EVENT_BUS.register(system);
+            }
         }
         eventsRegistered = true;
+    }
+
+    private boolean hasEventHandlers(AdaptiveSystem system) {
+        for (Method method : system.getClass().getMethods()) {
+            if (method.isAnnotationPresent(SubscribeEvent.class)) {
+                return true;
+            }
+        }
+        return false;
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent an `IllegalArgumentException` from the event bus when registering adaptive systems that do not declare any `@SubscribeEvent` listeners by avoiding registration for those instances.

### Description
- Add a reflection-based helper `hasEventHandlers(AdaptiveSystem)` that scans `system.getClass().getMethods()` for the `@SubscribeEvent` annotation.
- Update `registerEvents()` to call `NeoForge.EVENT_BUS.register(system)` only when `hasEventHandlers(system)` returns `true`.
- Import `net.neoforged.bus.api.SubscribeEvent` and `java.lang.reflect.Method` to support the annotation detection.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971afc5fe148328bcf7170e6b5f21c7)