### PR TITLE
Reduce render allocation churn in batching paths

### DIFF
--- a/src/main/java/com/thunder/novaapi/RenderEngine/overlay/OverlayBatcher.java
+++ b/src/main/java/com/thunder/novaapi/RenderEngine/overlay/OverlayBatcher.java
@@ -14,6 +14,9 @@ import java.util.function.Consumer;
 
 public final class OverlayBatcher {
     private static final List<OverlayCall> QUEUED_CALLS = new ArrayList<>();
+    private static final List<OverlayCall> RENDER_CALLS = new ArrayList<>();
+    private static final Map<ResourceLocation, List<OverlayCall>> GROUPED_CALLS = new LinkedHashMap<>();
+    private static final List<List<OverlayCall>> CALL_LIST_POOL = new ArrayList<>();
 
     private OverlayBatcher() {
     }
@@ -30,26 +33,31 @@ public final class OverlayBatcher {
     }
 
     public static void render(GuiGraphics graphics) {
-        List<OverlayCall> calls;
         synchronized (QUEUED_CALLS) {
             if (QUEUED_CALLS.isEmpty()) {
                 return;
             }
-            calls = new ArrayList<>(QUEUED_CALLS);
+            RENDER_CALLS.clear();
+            RENDER_CALLS.addAll(QUEUED_CALLS);
             QUEUED_CALLS.clear();
         }
 
         if (!RenderEngineConfig.isOverlayBatchingEnabled()) {
-            renderSequential(calls, graphics);
+            renderSequential(RENDER_CALLS, graphics);
             return;
         }
 
-        Map<ResourceLocation, List<OverlayCall>> grouped = new LinkedHashMap<>();
-        for (OverlayCall call : calls) {
-            grouped.computeIfAbsent(call.texture(), key -> new ArrayList<>()).add(call);
+        GROUPED_CALLS.clear();
+        for (OverlayCall call : RENDER_CALLS) {
+            List<OverlayCall> bucket = GROUPED_CALLS.get(call.texture());
+            if (bucket == null) {
+                bucket = acquireCallList();
+                GROUPED_CALLS.put(call.texture(), bucket);
+            }
+            bucket.add(call);
         }
 
-        for (Map.Entry<ResourceLocation, List<OverlayCall>> entry : grouped.entrySet()) {
+        for (Map.Entry<ResourceLocation, List<OverlayCall>> entry : GROUPED_CALLS.entrySet()) {
             ResourceLocation texture = entry.getKey();
             if (texture != null) {
                 RenderSystem.setShaderTexture(0, texture);
@@ -58,6 +66,12 @@ public final class OverlayBatcher {
                 call.drawCall().accept(graphics);
             }
         }
+
+        for (List<OverlayCall> list : GROUPED_CALLS.values()) {
+            list.clear();
+            CALL_LIST_POOL.add(list);
+        }
+        GROUPED_CALLS.clear();
     }
 
     private static void renderSequential(List<OverlayCall> calls, GuiGraphics graphics) {
@@ -67,6 +81,14 @@ public final class OverlayBatcher {
             }
             call.drawCall().accept(graphics);
         }
+    }
+
+    private static List<OverlayCall> acquireCallList() {
+        int lastIndex = CALL_LIST_POOL.size() - 1;
+        if (lastIndex >= 0) {
+            return CALL_LIST_POOL.remove(lastIndex);
+        }
+        return new ArrayList<>();
     }
 
     private record OverlayCall(ResourceLocation texture, Consumer<GuiGraphics> drawCall) {

--- a/src/main/java/com/thunder/novaapi/RenderEngine/particles/ParticleCullingManager.java
+++ b/src/main/java/com/thunder/novaapi/RenderEngine/particles/ParticleCullingManager.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 
 public final class ParticleCullingManager {
     private static final List<ParticleRenderRequest> QUEUED_REQUESTS = new ArrayList<>();
+    private static final List<ParticleRenderRequest> RENDER_REQUESTS = new ArrayList<>();
 
     private ParticleCullingManager() {
     }
@@ -23,17 +24,17 @@ public final class ParticleCullingManager {
     }
 
     public static void render(Frustum frustum, Vec3 cameraPosition) {
-        List<ParticleRenderRequest> requests;
         synchronized (QUEUED_REQUESTS) {
             if (QUEUED_REQUESTS.isEmpty()) {
                 return;
             }
-            requests = new ArrayList<>(QUEUED_REQUESTS);
+            RENDER_REQUESTS.clear();
+            RENDER_REQUESTS.addAll(QUEUED_REQUESTS);
             QUEUED_REQUESTS.clear();
         }
 
         if (!RenderEngineConfig.isParticleCullingEnabled()) {
-            for (ParticleRenderRequest request : requests) {
+            for (ParticleRenderRequest request : RENDER_REQUESTS) {
                 request.submit().run();
             }
             return;
@@ -42,7 +43,7 @@ public final class ParticleCullingManager {
         int maxDistance = RenderEngineConfig.getParticleCullingDistance();
         double maxDistanceSquared = maxDistance > 0 ? maxDistance * (double) maxDistance : Double.POSITIVE_INFINITY;
 
-        for (ParticleRenderRequest request : requests) {
+        for (ParticleRenderRequest request : RENDER_REQUESTS) {
             if (cameraPosition != null && cameraPosition.distanceToSqr(request.position()) > maxDistanceSquared) {
                 continue;
             }


### PR DESCRIPTION
### Motivation
- Reduce per-frame object allocations during rendering to lower GC pressure and improve FPS without altering gameplay.
- Target overlay batching and particle culling hotspots where temporary lists were being allocated each frame.

### Description
- Reused per-frame collection in `OverlayBatcher` by adding `RENDER_CALLS`, `GROUPED_CALLS`, and a small `CALL_LIST_POOL` to avoid allocating new lists for every render pass, and added `acquireCallList()` to recycle lists.
- Switched overlay rendering to populate and consume the pooled collections while keeping rendering semantics identical to before.
- Reused a single `RENDER_REQUESTS` list in `ParticleCullingManager` to replace the per-frame `new ArrayList<>(QUEUED_REQUESTS)` copy in the particle culling path.
- Changes are confined to `src/main/java/com/thunder/novaapi/RenderEngine/overlay/OverlayBatcher.java` and `src/main/java/com/thunder/novaapi/RenderEngine/particles/ParticleCullingManager.java` and do not change rendering behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971b1920004832882bc5b578e3f1525)