### PR TITLE
Apply gameplay lag controls to chunk runtime systems

### DIFF
--- a/src/main/java/com/thunder/novaapi/config/NovaAPIConfig.java
+++ b/src/main/java/com/thunder/novaapi/config/NovaAPIConfig.java
@@ -10,6 +10,9 @@ public class NovaAPIConfig {
     public static final ModConfigSpec.BooleanValue ENABLE_NOVA_API;
     public static final ModConfigSpec.BooleanValue MODPACK_RESOURCE_PROFILE;
     public static final ModConfigSpec.BooleanValue ENABLE_MEMORY_THREAD_LOGS;
+    public static final ModConfigSpec.BooleanValue ENABLE_DEBUG_COMMANDS;
+    public static final ModConfigSpec.BooleanValue ENABLE_AI_PERFORMANCE_ADVISOR;
+    public static final ModConfigSpec.BooleanValue ENABLE_AUTOMATIC_PERFORMANCE_MITIGATIONS;
 
     // 🔹 Chunk Optimization Settings
     public static final ModConfigSpec.BooleanValue ENABLE_CHUNK_OPTIMIZATIONS;
@@ -30,6 +33,15 @@ public class NovaAPIConfig {
         ENABLE_MEMORY_THREAD_LOGS = BUILDER
                 .comment("Enable debug logs for memory usage and thread counts.")
                 .define("enableMemoryThreadLogs", false);
+        ENABLE_DEBUG_COMMANDS = BUILDER
+                .comment("Register NovaAPI debug and profiling commands. Disable on production servers to reduce overhead.")
+                .define("enableDebugCommands", false);
+        ENABLE_AI_PERFORMANCE_ADVISOR = BUILDER
+                .comment("Enable periodic AI performance advisor analysis and recommendation logging.")
+                .define("enableAiPerformanceAdvisor", false);
+        ENABLE_AUTOMATIC_PERFORMANCE_MITIGATIONS = BUILDER
+                .comment("Enable automatic mitigation tick processing (pathfinding throttle, distance adjustments, etc.).")
+                .define("enableAutomaticPerformanceMitigations", true);
         BUILDER.pop();
 
         BUILDER.push("Chunk Optimization Settings");
@@ -66,6 +78,55 @@ public class NovaAPIConfig {
             return ENABLE_MEMORY_THREAD_LOGS.get();
         } catch (IllegalStateException ex) {
             return ENABLE_MEMORY_THREAD_LOGS.getDefault();
+        }
+    }
+
+
+    public static boolean isChunkOptimizationsEnabled() {
+        try {
+            return ENABLE_CHUNK_OPTIMIZATIONS.get();
+        } catch (IllegalStateException ex) {
+            return ENABLE_CHUNK_OPTIMIZATIONS.getDefault();
+        }
+    }
+
+    public static boolean isAsyncChunkLoadingEnabled() {
+        try {
+            return ASYNC_CHUNK_LOADING.get();
+        } catch (IllegalStateException ex) {
+            return ASYNC_CHUNK_LOADING.getDefault();
+        }
+    }
+
+    public static boolean isSmartChunkRetentionEnabled() {
+        try {
+            return SMART_CHUNK_RETENTION.get();
+        } catch (IllegalStateException ex) {
+            return SMART_CHUNK_RETENTION.getDefault();
+        }
+    }
+
+    public static boolean isDebugCommandsEnabled() {
+        try {
+            return ENABLE_DEBUG_COMMANDS.get();
+        } catch (IllegalStateException ex) {
+            return ENABLE_DEBUG_COMMANDS.getDefault();
+        }
+    }
+
+    public static boolean isAiPerformanceAdvisorEnabled() {
+        try {
+            return ENABLE_AI_PERFORMANCE_ADVISOR.get();
+        } catch (IllegalStateException ex) {
+            return ENABLE_AI_PERFORMANCE_ADVISOR.getDefault();
+        }
+    }
+
+    public static boolean isAutomaticPerformanceMitigationsEnabled() {
+        try {
+            return ENABLE_AUTOMATIC_PERFORMANCE_MITIGATIONS.get();
+        } catch (IllegalStateException ex) {
+            return ENABLE_AUTOMATIC_PERFORMANCE_MITIGATIONS.getDefault();
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Gameplay features related to chunk loading and retention were declarative but did not always affect per-tick runtime work, which can cause lag or FPS drops during play. 
- Provide operators and pack authors a way to materially reduce per-tick chunk work and I/O pressure using existing config flags. 
- Keep modpack profiling and user-selected gameplay toggles composable so aggressive clamps can still be applied where needed.

### Description
- Added safe accessors in `NovaAPIConfig` for `isChunkOptimizationsEnabled()`, `isAsyncChunkLoadingEnabled()`, and `isSmartChunkRetentionEnabled()` so flags can be read reliably before config fully loads. 
- Gate per-tick chunk throttling by wrapping `ChunkTickThrottler.tick(...)` with `if (NovaAPIConfig.isChunkOptimizationsEnabled())` in `NovaAPI.onServerTick`. 
- Reworked `resolveChunkConfig()` to make gameplay toggles affect runtime behavior by disabling chunk streaming when `enableChunkOptimizations` is off, forcing single-threaded chunk I/O when `asyncChunkLoading` is off, and clamping cache sizes and ticket TTLs when `smartChunkRetention` is off; `modpack` clamps are layered on top. 
- Also gated AI advisor/mitigation behavior and debug commands behind the existing config accessors so those subsystems no longer run when disabled.

### Testing
- Ran `./gradlew compileJava`, which completed successfully (`BUILD SUCCESSFUL`) with the existing deprecation warnings preserved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984def353c483288d818fb34ca708d2)