### PR TITLE
Add per-feature config toggles

### DIFF
--- a/src/main/java/com/thunder/novaapi/RenderEngine/RenderEngineConfig.java
+++ b/src/main/java/com/thunder/novaapi/RenderEngine/RenderEngineConfig.java
@@ -1,6 +1,7 @@
 package com.thunder.novaapi.RenderEngine;
 
 import net.neoforged.neoforge.common.ModConfigSpec;
+import com.thunder.novaapi.config.NovaAPIConfig;
 
 public final class RenderEngineConfig {
     public static final ModConfigSpec CONFIG_SPEC;
@@ -48,11 +49,11 @@ public final class RenderEngineConfig {
     }
 
     public static boolean isOverlayBatchingEnabled() {
-        return ENABLE_OVERLAY_BATCHING.get();
+        return NovaAPIConfig.isRenderEngineOptimizationsEnabled() && ENABLE_OVERLAY_BATCHING.get();
     }
 
     public static boolean isParticleCullingEnabled() {
-        return ENABLE_PARTICLE_CULLING.get();
+        return NovaAPIConfig.isRenderEngineOptimizationsEnabled() && ENABLE_PARTICLE_CULLING.get();
     }
 
     public static int getParticleCullingDistance() {
@@ -60,7 +61,7 @@ public final class RenderEngineConfig {
     }
 
     public static boolean isInstancedRenderingEnabled() {
-        return ENABLE_INSTANCED_RENDERING.get();
+        return NovaAPIConfig.isRenderEngineOptimizationsEnabled() && ENABLE_INSTANCED_RENDERING.get();
     }
 
     public static double getInstancedLod0Distance() {

--- a/src/main/java/com/thunder/novaapi/cache/ModDataCacheConfig.java
+++ b/src/main/java/com/thunder/novaapi/cache/ModDataCacheConfig.java
@@ -35,7 +35,7 @@ public final class ModDataCacheConfig {
      * Returns whether the cache is enabled.
      */
     public static boolean isCacheEnabled() {
-        return enableCache.get();
+        return NovaAPIConfig.isModDataCacheEnabled() && enableCache.get();
     }
 
     /**

--- a/src/main/java/com/thunder/novaapi/config/NovaAPIConfig.java
+++ b/src/main/java/com/thunder/novaapi/config/NovaAPIConfig.java
@@ -13,6 +13,11 @@ public class NovaAPIConfig {
     public static final ModConfigSpec.BooleanValue ENABLE_DEBUG_COMMANDS;
     public static final ModConfigSpec.BooleanValue ENABLE_AI_PERFORMANCE_ADVISOR;
     public static final ModConfigSpec.BooleanValue ENABLE_AUTOMATIC_PERFORMANCE_MITIGATIONS;
+    public static final ModConfigSpec.BooleanValue ENABLE_ASYNC_TASKS;
+    public static final ModConfigSpec.BooleanValue ENABLE_CHUNK_STREAMING;
+    public static final ModConfigSpec.BooleanValue ENABLE_MOD_DATA_CACHE;
+    public static final ModConfigSpec.BooleanValue ENABLE_RESOURCEPACK_OPTIMIZATIONS;
+    public static final ModConfigSpec.BooleanValue ENABLE_RENDER_ENGINE_OPTIMIZATIONS;
 
     // 🔹 Chunk Optimization Settings
     public static final ModConfigSpec.BooleanValue ENABLE_CHUNK_OPTIMIZATIONS;
@@ -44,6 +49,24 @@ public class NovaAPIConfig {
                 .define("enableAutomaticPerformanceMitigations", true);
         BUILDER.pop();
 
+        BUILDER.push("Feature Toggles");
+        ENABLE_ASYNC_TASKS = BUILDER
+                .comment("Enable the async task system (worker threads, task queues).")
+                .define("enableAsyncTasks", true);
+        ENABLE_CHUNK_STREAMING = BUILDER
+                .comment("Enable the chunk streaming pipeline and related optimizations.")
+                .define("enableChunkStreaming", true);
+        ENABLE_MOD_DATA_CACHE = BUILDER
+                .comment("Enable the persistent mod data cache for downloadable content.")
+                .define("enableModDataCache", true);
+        ENABLE_RESOURCEPACK_OPTIMIZATIONS = BUILDER
+                .comment("Enable NovaAPI resource pack optimization features.")
+                .define("enableResourcepackOptimizations", true);
+        ENABLE_RENDER_ENGINE_OPTIMIZATIONS = BUILDER
+                .comment("Enable NovaAPI render engine optimizations (batching, culling, instancing).")
+                .define("enableRenderEngineOptimizations", true);
+        BUILDER.pop();
+
         BUILDER.push("Chunk Optimization Settings");
         ENABLE_CHUNK_OPTIMIZATIONS = BUILDER
                 .comment("Enable optimized chunk loading and retention.")
@@ -70,6 +93,54 @@ public class NovaAPIConfig {
             return MODPACK_RESOURCE_PROFILE.get();
         } catch (IllegalStateException ex) {
             return MODPACK_RESOURCE_PROFILE.getDefault();
+        }
+    }
+
+    public static boolean isNovaApiEnabled() {
+        try {
+            return ENABLE_NOVA_API.get();
+        } catch (IllegalStateException ex) {
+            return ENABLE_NOVA_API.getDefault();
+        }
+    }
+
+    public static boolean isAsyncSystemEnabled() {
+        try {
+            return isNovaApiEnabled() && ENABLE_ASYNC_TASKS.get();
+        } catch (IllegalStateException ex) {
+            return isNovaApiEnabled() && ENABLE_ASYNC_TASKS.getDefault();
+        }
+    }
+
+    public static boolean isChunkStreamingEnabled() {
+        try {
+            return isNovaApiEnabled() && ENABLE_CHUNK_STREAMING.get();
+        } catch (IllegalStateException ex) {
+            return isNovaApiEnabled() && ENABLE_CHUNK_STREAMING.getDefault();
+        }
+    }
+
+    public static boolean isModDataCacheEnabled() {
+        try {
+            return isNovaApiEnabled() && ENABLE_MOD_DATA_CACHE.get();
+        } catch (IllegalStateException ex) {
+            return isNovaApiEnabled() && ENABLE_MOD_DATA_CACHE.getDefault();
+        }
+    }
+
+    public static boolean isResourcePackOptimizationsEnabled() {
+        try {
+            return isNovaApiEnabled() && ENABLE_RESOURCEPACK_OPTIMIZATIONS.get();
+        } catch (IllegalStateException ex) {
+            return isNovaApiEnabled() && ENABLE_RESOURCEPACK_OPTIMIZATIONS.getDefault();
+        }
+    }
+
+    public static boolean isRenderEngineOptimizationsEnabled() {
+        try {
+            return isNovaApiEnabled() && ENABLE_RENDER_ENGINE_OPTIMIZATIONS.get();
+        } catch (IllegalStateException ex) {
+            return isNovaApiEnabled() && ENABLE_RENDER_ENGINE_OPTIMIZATIONS.getDefault();
         }
     }
 

--- a/src/main/java/com/thunder/novaapi/resourcepack/ResourcePackOptimizationConfig.java
+++ b/src/main/java/com/thunder/novaapi/resourcepack/ResourcePackOptimizationConfig.java
@@ -1,6 +1,7 @@
 package com.thunder.novaapi.resourcepack;
 
 import net.neoforged.neoforge.common.ModConfigSpec;
+import com.thunder.novaapi.config.NovaAPIConfig;
 
 /**
  * Configuration toggles for optimizing resource pack caching and activation.
@@ -41,7 +42,7 @@ public final class ResourcePackOptimizationConfig {
     }
 
     public static boolean isOptimizationEnabled() {
-        return enableOptimization.get();
+        return NovaAPIConfig.isResourcePackOptimizationsEnabled() && enableOptimization.get();
     }
 
     public static boolean isRemoteDownloadAllowed() {


### PR DESCRIPTION
### Motivation
- Replace a single global on/off switch with independent toggles so individual NovaAPI subsystems and optimizations can be enabled or disabled separately.
- Give modpack authors and server operators fine-grained control to avoid compatibility or performance impacts from specific systems while keeping others active.

### Description
- Added per-feature boolean config entries and accessors to `NovaAPIConfig` for async tasks, chunk streaming, mod data cache, resourcepack optimizations, and render-engine optimizations (all gated by the global NovaAPI flag via the accessors).
- Wired those accessors into lifecycle and runtime paths in `NovaAPI` to conditionally initialize, tick, flush, restart, and shutdown each subsystem (`AsyncTaskManager`, `ChunkStreamManager`, `IoExecutors`, `ChunkDeltaTracker`, etc.).
- Updated feature-specific config helpers to respect the new common toggles by gating `ModDataCacheConfig.isCacheEnabled()`, `ResourcePackOptimizationConfig.isOptimizationEnabled()`, and the `RenderEngineConfig` enable checks behind the `NovaAPIConfig` flags.
- Cleaned up restart/shutdown paths (`restartAsyncSystems`, `restartChunkStreaming`, `initializeAsyncAndChunkSystems`, `onConfigLoaded`/`onConfigReloaded`, and `onServerStopping`) to avoid starting systems when their per-feature toggle is off.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698630403cd083288a1d30fac4073e13)